### PR TITLE
Refactor: Group component properties into settings objects

### DIFF
--- a/Source/ANDMR_CEdit.pas
+++ b/Source/ANDMR_CEdit.pas
@@ -22,7 +22,7 @@ type
     FMaxLength: Integer;
     FPasswordChar: Char;
     FReadOnly: Boolean;
-    FActiveColor: TColor; // Retained for now for Paint logic
+    // FActiveColor: TColor; // Removed
     FCaretVisible: Boolean;
     FCaretPosition: Integer;
     FCaretTimer: TTimer;
@@ -51,7 +51,7 @@ type
     procedure SetCornerRadius(const Value: Integer);
     function GetRoundCornerType: TRoundCornerType;
     procedure SetRoundCornerType(const Value: TRoundCornerType);
-    procedure SetActiveColor(const Value: TColor); // Direct field write for now
+    // procedure SetActiveColor(const Value: TColor); // Removed
     function GetInactiveColor: TColor;
     procedure SetInactiveColor(const Value: TColor);
     function GetBorderColor: TColor;
@@ -146,7 +146,7 @@ type
     property ReadOnly: Boolean read FReadOnly write SetReadOnly default False;
     property CornerRadius: Integer read GetCornerRadius write SetCornerRadius default 8;
     property RoundCornerType: TRoundCornerType read GetRoundCornerType write SetRoundCornerType default rctAll;
-    property ActiveColor: TColor read FActiveColor write SetActiveColor default clHighlight; // Stays direct for now
+    // property ActiveColor: TColor read FActiveColor write SetActiveColor default clHighlight; // Removed
     property InactiveColor: TColor read GetInactiveColor write SetInactiveColor default clBtnFace; // Delegates to FBorderSettings.BackgroundColor
     property BorderColor: TColor read GetBorderColor write SetBorderColor default clBlack;
     property BorderThickness: Integer read GetBorderThickness write SetBorderThickness default 1;
@@ -236,7 +236,7 @@ begin
   FMaxLength := 0;
   FPasswordChar := #0;
   FReadOnly := False;
-  FActiveColor := clHighlight; // Default for FActiveColor (still direct)
+  // FActiveColor := clHighlight; // Removed
   Font.Name := 'Segoe UI';
   Font.Size := 9;
   Font.Color := clWindowText;
@@ -253,8 +253,8 @@ begin
 
   FFocusSettings := TFocusSettings.Create;
   FFocusSettings.OnChange := SettingsChanged;
-  FFocusSettings.BorderColorVisible := False;
-  FFocusSettings.BorderColor := clBlack; // Default focus border color, FActiveColor also plays a role
+  FFocusSettings.BorderColorVisible := True; // Changed
+  FFocusSettings.BorderColor := clHighlight; // Changed
   FFocusSettings.BackgroundColorVisible := False;
   FFocusSettings.BackgroundColor := clWindow;
   FFocusSettings.UnderlineVisible := False;
@@ -458,7 +458,7 @@ function TANDMR_CEdit.GetCornerRadius: Integer; begin Result := FBorderSettings.
 procedure TANDMR_CEdit.SetCornerRadius(const Value: Integer); begin FBorderSettings.CornerRadius := Value; end;
 function TANDMR_CEdit.GetRoundCornerType: TRoundCornerType; begin Result := FBorderSettings.RoundCornerType; end;
 procedure TANDMR_CEdit.SetRoundCornerType(const Value: TRoundCornerType); begin FBorderSettings.RoundCornerType := Value; end;
-procedure TANDMR_CEdit.SetActiveColor(const Value: TColor); begin if FActiveColor <> Value then begin FActiveColor := Value; Invalidate; end; end; // Stays direct for now
+// procedure TANDMR_CEdit.SetActiveColor(const Value: TColor); // Removed
 function TANDMR_CEdit.GetInactiveColor: TColor; begin Result := FBorderSettings.BackgroundColor; end;
 procedure TANDMR_CEdit.SetInactiveColor(const Value: TColor); begin FBorderSettings.BackgroundColor := Value; end;
 function TANDMR_CEdit.GetBorderColor: TColor; begin Result := FBorderSettings.Color; end;
@@ -836,7 +836,7 @@ begin
       HoverCaptionColFromSettings := IfThen(FHoverSettings.Enabled, FHoverSettings.CaptionFontColor, clNone);
 
       FocusEditBGFromSettings := IfThen(FFocusSettings.BackgroundColorVisible, FFocusSettings.BackgroundColor, clNone);
-      FocusBorderColFromSettings := IfThen(FFocusSettings.BorderColorVisible, FFocusSettings.BorderColor, FActiveColor); // FActiveColor is direct
+      FocusBorderColFromSettings := FFocusSettings.BorderColor; // Changed: FActiveColor removed, ResolveStateColor handles visibility
       FocusTextColFromSettings := TrueBaseTextCol;
       FocusCaptionColFromSettings := TrueBaseCaptionCol;
 

--- a/Source/ANDMR_CMemo.pas
+++ b/Source/ANDMR_CMemo.pas
@@ -24,7 +24,7 @@ type
     // Fields specific to TANDMR_CMemo or retained temporarily
     FCaptionRect: TRect;
     FHovered: Boolean;
-    FActiveColor: TColor; // Retained for now (used for focus border if FFocusSettings.BorderColor is not set)
+    // FActiveColor: TColor; // Removed
 
     FOpacity: Byte;
     FInternalMemo: TMemo;
@@ -54,7 +54,7 @@ type
     procedure SetCornerRadius(const Value: Integer);
     function GetRoundCornerType: TRoundCornerType;
     procedure SetRoundCornerType(const Value: TRoundCornerType);
-    procedure SetActiveColor(const Value: TColor);
+    // procedure SetActiveColor(const Value: TColor); // Removed
     function GetInactiveColor: TColor;
     procedure SetInactiveColor(const Value: TColor);
     function GetBorderColor: TColor;
@@ -158,7 +158,7 @@ type
     // Appearance Properties
     property CornerRadius: Integer read GetCornerRadius write SetCornerRadius default 8;
     property RoundCornerType: TRoundCornerType read GetRoundCornerType write SetRoundCornerType default rctAll;
-    property ActiveColor: TColor read FActiveColor write SetActiveColor default clHighlight;
+    // property ActiveColor: TColor read FActiveColor write SetActiveColor default clHighlight; // Removed
     property InactiveColor: TColor read GetInactiveColor write SetInactiveColor default clBtnFace;
     property BorderColor: TColor read GetBorderColor write SetBorderColor default clBlack;
     property BorderThickness: Integer read GetBorderThickness write SetBorderThickness default 1;
@@ -247,8 +247,8 @@ begin
 
   FFocusSettings := TFocusSettings.Create;
   FFocusSettings.OnChange := SettingsChanged;
-  FFocusSettings.BorderColorVisible := False;
-  FFocusSettings.BorderColor := clBlack;
+  FFocusSettings.BorderColorVisible := True; // Changed
+  FFocusSettings.BorderColor := clHighlight; // Changed
   FFocusSettings.BackgroundColorVisible := False;
   FFocusSettings.BackgroundColor := clWindow;
   FFocusSettings.UnderlineVisible := False;
@@ -280,7 +280,7 @@ begin
   FTextMargins := TANDMR_Margins.Create;
   FTextMargins.OnChange := TextMarginsChanged;
 
-  FActiveColor := clHighlight;
+  // FActiveColor := clHighlight; // Removed
   FCaptionRect := Rect(0,0,0,0);
   FHovered := False;
   FOpacity := 255;
@@ -422,7 +422,7 @@ function TANDMR_CMemo.GetCornerRadius: Integer; begin Result := FBorderSettings.
 procedure TANDMR_CMemo.SetCornerRadius(const Value: Integer); begin FBorderSettings.CornerRadius := Value; end;
 function TANDMR_CMemo.GetRoundCornerType: TRoundCornerType; begin Result := FBorderSettings.RoundCornerType; end;
 procedure TANDMR_CMemo.SetRoundCornerType(const Value: TRoundCornerType); begin FBorderSettings.RoundCornerType := Value; end;
-procedure TANDMR_CMemo.SetActiveColor(const Value: TColor); begin if FActiveColor <> Value then begin FActiveColor := Value; Invalidate; end; end;
+// procedure TANDMR_CMemo.SetActiveColor(const Value: TColor); // Removed
 function TANDMR_CMemo.GetInactiveColor: TColor; begin Result := FBorderSettings.BackgroundColor; end;
 procedure TANDMR_CMemo.SetInactiveColor(const Value: TColor); begin FBorderSettings.BackgroundColor := Value; end;
 function TANDMR_CMemo.GetBorderColor: TColor; begin Result := FBorderSettings.Color; end;
@@ -919,7 +919,7 @@ begin
 
       var FocusFrameBG, FocusBorderColor, FocusMemoBG, FocusMemoFontColor, FocusCaptionColor: TColor;
       FocusFrameBG := clNone;
-      FocusBorderColor := IfThen(FFocusSettings.BorderColorVisible, FFocusSettings.BorderColor, FActiveColor);
+      FocusBorderColor := FFocusSettings.BorderColor; // Changed: FActiveColor removed, ResolveStateColor handles visibility
       FocusMemoBG := IfThen(FFocusSettings.BackgroundColorVisible, FFocusSettings.BackgroundColor, clNone);
       FocusMemoFontColor := BaseMemoFontColor;
       FocusCaptionColor := BaseCaptionColor;

--- a/Source/ANDMR_CPanel.pas
+++ b/Source/ANDMR_CPanel.pas
@@ -265,20 +265,19 @@ begin
   Result := FCaptionSettings.Font;
 end;
 
-procedure TANDMR_CPanel.SetFont(Value: TFont); // Removed 'override'
+procedure TANDMR_CPanel.SetFont(Value: TFont);
 begin
-  // Directly assign to the component's Font property.
-  // This will use the VCL's property setter for TCustomControl.Font.
-  Self.Font.Assign(Value); // This calls the inherited property setter
-
-  // FCaptionSettings.Font.OnChange will trigger FCaptionSettings.Changed,
-  // which in turn calls Self.SettingsChanged, leading to Invalidate.
-  // So, an explicit Invalidate here might be redundant if FCaptionSettings.Font.Assign
-  // correctly triggers its OnChange. However, to be safe and ensure propagation:
-  if Assigned(FCaptionSettings) and Assigned(FCaptionSettings.Font) then
-     FCaptionSettings.Font.Assign(Self.Font); // Ensure caption font is also updated
-
-  Invalidate; // Ensure repaint after font change
+  // The published Font property should directly control the caption's font.
+  // FCaptionSettings.Font.Assign will trigger FCaptionSettings.Font.OnChange,
+  // which in turn calls FCaptionSettings.Changed, which calls Self.SettingsChanged.
+  FCaptionSettings.Font.Assign(Value);
+  // The Invalidate call here is therefore redundant if FCaptionSettings.OnChange works.
+  // However, keeping it for safety or if direct sub-property changes of Font
+  // (e.g., Font.Name := 'Arial') are made elsewhere and don't trigger through Assign.
+  // For now, let's assume FCaptionSettings.OnChange is sufficient.
+  // If Self.Invalidate is still needed, it can be added back, but
+  // TCaptionSettings.FontChanged calls Changed, which calls FOnChange, which is Self.SettingsChanged.
+  // Self.SettingsChanged calls Invalidate. So it should be fine.
 end;
 
 function TANDMR_CPanel.GetDropShadowEnabled: Boolean; begin Result := FDropShadowSettings.Enabled; end;


### PR DESCRIPTION
I revised components (ANDMR_CButton, ANDMR_CCheckBox, ANDMR_CEdit, ANDMR_CMemo, ANDMR_CPanel) to consolidate related properties into existing settings classes (e.g., TCaptionSettings, TImageSettings, TFocusSettings) defined in ANDMR_ComponentUtils.pas.

- I centralized management of text, image, border, focus, and caption properties within their respective settings objects.
- I removed redundant direct fields and updated accessors and paint logic to use the new settings objects.
- I integrated 'ActiveColor' properties from CEdit and CMemo into FFocusSettings for consistent focus state handling.
- I clarified Font property usage in CPanel to directly manage FCaptionSettings.Font.

This refactoring aims to improve code organization and maintainability by reducing duplicated property declarations and standardizing property access.