### PR TITLE
Refactor: Update components to use ANDMR_ComponentUtils classes

### DIFF
--- a/Source/ANDMR_CCheckBox.pas
+++ b/Source/ANDMR_CCheckBox.pas
@@ -22,28 +22,24 @@ type
     FTransparent: Boolean;
     FOnClick: TNotifyEvent;
     FOnCheckChanged: TNotifyEvent;
-    FInternalHoverSettings: THoverSettings;
+    FHoverSettings: THoverSettings;
+    procedure SetBorderSettings(const Value: TBorderSettings);
 
-    function GetChecked: Boolean; // Added
+    function GetChecked: Boolean;
     procedure SetChecked(const Value: Boolean);
-    procedure SetState(const Value: TCheckBoxState); // Added
-    function GetCaption: string; // Added
+    procedure SetState(const Value: TCheckBoxState);
+    function GetCaption: string;
     procedure SetCaption(const Value: string);
-    function GetCornerRadius: Integer; // Getter
-    procedure SetCornerRadius(const Value: Integer); // Setter
-    function GetRoundCornerType: TRoundCornerType; // Getter
-    procedure SetRoundCornerType(const Value: TRoundCornerType); // Setter
     procedure SetBoxColorUnchecked(const Value: TColor);
     procedure SetBoxColorChecked(const Value: TColor);
     procedure SetCheckMarkColor(const Value: TColor);
-    function GetTitleFont: TFont; // Added
-    procedure SetTitleFont(const Value: TFont);
+    procedure SetCaptionSettings(const Value: TCaptionSettings);
     procedure SetTransparent(const Value: Boolean);
-    procedure SetInternalHoverSettings(const Value: THoverSettings);
+    procedure SetHoverSettings(const Value: THoverSettings);
     procedure SetEnabled(Value: Boolean);
 
-    procedure InternalHoverSettingsChanged(Sender: TObject);
-    procedure SettingsChanged(Sender: TObject); // Added
+    procedure HoverSettingsChanged(Sender: TObject);
+    procedure SettingsChanged(Sender: TObject);
 
   protected
     procedure CMEnabledChanged(var Message: TMessage); message CM_ENABLEDCHANGED;
@@ -57,18 +53,21 @@ type
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
 
-    property InternalHoverSettings: THoverSettings read FInternalHoverSettings write SetInternalHoverSettings;
+    // property InternalHoverSettings: THoverSettings read FInternalHoverSettings write SetInternalHoverSettings; // Removed
+    property HoverSettings: THoverSettings read FHoverSettings write SetHoverSettings; // New
 
   published
     property Checked: Boolean read GetChecked write SetChecked;
-    property State: TCheckBoxState read FState write SetState; // Added
-    property Caption: string read GetCaption write SetCaption; // Changed
-    property CornerRadius: Integer read GetCornerRadius write SetCornerRadius;
-    property RoundCornerType: TRoundCornerType read GetRoundCornerType write SetRoundCornerType;
+    property State: TCheckBoxState read FState write SetState;
+    property Caption: string read GetCaption write SetCaption;
+    property BorderSettings: TBorderSettings read FBorderSettings write SetBorderSettings;
+    // property CornerRadius: Integer read GetCornerRadius write SetCornerRadius;
+    // property RoundCornerType: TRoundCornerType read GetRoundCornerType write SetRoundCornerType;
+    property CaptionSettings: TCaptionSettings read FCaptionSettings write SetCaptionSettings; // New
     property BoxColorUnchecked: TColor read FBoxColorUnchecked write SetBoxColorUnchecked;
     property BoxColorChecked: TColor read FBoxColorChecked write SetBoxColorChecked;
     property CheckMarkColor: TColor read FCheckMarkColor write SetCheckMarkColor;
-    property TitleFont: TFont read GetTitleFont write SetTitleFont; // Changed
+    // property TitleFont: TFont read GetTitleFont write SetTitleFont; // Removed
     property Transparent: Boolean read FTransparent write SetTransparent;
     property Enabled: Boolean read GetEnabled write SetEnabled;
     property OnClick: TNotifyEvent read FOnClick write FOnClick;
@@ -122,16 +121,16 @@ begin
     ControlStyle := ControlStyle + [csOpaque] - [csParentBackground];
 
   // FTitleFont := TFont.Create; // Removed
-  // FTitleFont.Name := 'Segoe UI'; // Removed
-  // FTitleFont.Size := 9; // Removed
-  // FTitleFont.Color := clWindowText; // Removed
+  // FTitleFont.Name := 'Segoe UI';
+  // FTitleFont.Size := 9;
+  // FTitleFont.Color := clWindowText;
 
-  FInternalHoverSettings := THoverSettings.Create(Self);
-  FInternalHoverSettings.OnChange := InternalHoverSettingsChanged;
-  FInternalHoverSettings.BackgroundColor := clNone;
-  FInternalHoverSettings.BorderColor := clNone;
-  FInternalHoverSettings.FontColor := clNone;
-  FInternalHoverSettings.Enabled := True;
+  FHoverSettings := THoverSettings.Create(Self); // Renamed
+  FHoverSettings.OnChange := HoverSettingsChanged; // Renamed
+  FHoverSettings.BackgroundColor := clNone;
+  FHoverSettings.BorderColor := clNone;
+  FHoverSettings.FontColor := clNone;
+  FHoverSettings.Enabled := True;
 
   // Temp FTitleFont to assign to FCaptionSettings, as original FTitleFont is removed
   var TempTitleFont: TFont;
@@ -166,11 +165,11 @@ begin
     FBorderSettings := nil;
   end;
 
-  if Assigned(FInternalHoverSettings) then
+  if Assigned(FHoverSettings) then // Renamed
   begin
-    FInternalHoverSettings.OnChange := nil;
-    FInternalHoverSettings.Free;
-    FInternalHoverSettings := nil;
+    FHoverSettings.OnChange := nil; // Renamed
+    FHoverSettings.Free; // Renamed
+    FHoverSettings := nil; // Renamed
   end;
 
   if Assigned(FCaptionSettings) then
@@ -195,7 +194,19 @@ begin
   Invalidate;
 end;
 
-procedure TANDMR_CCheckBox.InternalHoverSettingsChanged(Sender: TObject);
+procedure TANDMR_CCheckBox.SetBorderSettings(const Value: TBorderSettings);
+begin
+  FBorderSettings.Assign(Value);
+  Invalidate;
+end;
+
+procedure TANDMR_CCheckBox.SetCaptionSettings(const Value: TCaptionSettings);
+begin
+  FCaptionSettings.Assign(Value);
+  Invalidate;
+end;
+
+procedure TANDMR_CCheckBox.HoverSettingsChanged(Sender: TObject); // Renamed
 begin
   Invalidate;
 end;
@@ -209,18 +220,18 @@ end;
 procedure TANDMR_CCheckBox.CMMouseEnter(var Message: TMessage);
 begin
   inherited;
-  if Self.Enabled and Assigned(FInternalHoverSettings) and FInternalHoverSettings.Enabled then
+  if Self.Enabled and Assigned(FHoverSettings) and FHoverSettings.Enabled then // Renamed
   begin
-    FInternalHoverSettings.StartAnimation(True);
+    FHoverSettings.StartAnimation(True); // Renamed
   end;
 end;
 
 procedure TANDMR_CCheckBox.CMMouseLeave(var Message: TMessage);
 begin
   inherited;
-  if Assigned(FInternalHoverSettings) then
+  if Assigned(FHoverSettings) then // Renamed
   begin
-    FInternalHoverSettings.StartAnimation(False);
+    FHoverSettings.StartAnimation(False); // Renamed
   end;
 end;
 
@@ -300,8 +311,8 @@ begin
 
     CaptionRect := Rect(Round(BoxRect.X + BoxRect.Width + Padding), 0, Self.Width - Padding, Self.Height);
 
-    LIsHovering := FInternalHoverSettings.Enabled and (FInternalHoverSettings.CurrentAnimationValue > 0) and Self.Enabled;
-    LHoverProgress := FInternalHoverSettings.CurrentAnimationValue / 255.0;
+    LIsHovering := FHoverSettings.Enabled and (FHoverSettings.CurrentAnimationValue > 0) and Self.Enabled; // Renamed
+    LHoverProgress := FHoverSettings.CurrentAnimationValue / 255.0; // Renamed
 
     // LCurrentBoxColor := IfThen(FChecked, FBoxColorChecked, FBoxColorUnchecked);
     case FState of
@@ -318,11 +329,11 @@ begin
 
     if LIsHovering then
     begin
-      if FInternalHoverSettings.BackgroundColor <> clNone then
-        LCurrentBoxColor := BlendColors(LCurrentBoxColor, FInternalHoverSettings.BackgroundColor, LHoverProgress);
-      // Hover caption color from FInternalHoverSettings.CaptionFontColor
-      if FInternalHoverSettings.CaptionFontColor <> clNone then
-        LCurrentCaptionColor := BlendColors(LCurrentCaptionColor, FInternalHoverSettings.CaptionFontColor, LHoverProgress);
+      if FHoverSettings.BackgroundColor <> clNone then // Renamed
+        LCurrentBoxColor := BlendColors(LCurrentBoxColor, FHoverSettings.BackgroundColor, LHoverProgress); // Renamed
+      // Hover caption color from FHoverSettings.CaptionFontColor
+      if FHoverSettings.CaptionFontColor <> clNone then // Renamed
+        LCurrentCaptionColor := BlendColors(LCurrentCaptionColor, FHoverSettings.CaptionFontColor, LHoverProgress); // Renamed
     end;
 
     if not Self.Enabled then
@@ -336,9 +347,9 @@ begin
         LCurrentCaptionColor := BlendColors(LCurrentCaptionColor, clGray, 0.50);
     end;
 
-    LBoxBorderColor := DarkerColor(LCurrentBoxColor, IfThen(LIsHovering and (FInternalHoverSettings.BorderColor = clNone), 15, 5));
-    if LIsHovering and (FInternalHoverSettings.BorderColor <> clNone) then
-        LBoxBorderColor := BlendColors(LBoxBorderColor, FInternalHoverSettings.BorderColor, LHoverProgress);
+    LBoxBorderColor := DarkerColor(LCurrentBoxColor, IfThen(LIsHovering and (FHoverSettings.BorderColor = clNone), 15, 5)); // Renamed
+    if LIsHovering and (FHoverSettings.BorderColor <> clNone) then // Renamed
+        LBoxBorderColor := BlendColors(LBoxBorderColor, FHoverSettings.BorderColor, LHoverProgress); // Renamed
 
     if FTransparent then
       LBoxFillColor := clNone
@@ -464,8 +475,11 @@ end;
 
 procedure TANDMR_CCheckBox.SetCaption(const Value: string);
 begin
-  FCaptionSettings.Text := Value;
-  // Invalidation is handled by FCaptionSettings.OnChange via SettingsChanged
+  if FCaptionSettings.Text <> Value then
+  begin
+    FCaptionSettings.Text := Value;
+    Invalidate; // Ensure repaint on caption change
+  end;
 end;
 
 function TANDMR_CCheckBox.GetChecked: Boolean;
@@ -511,48 +525,38 @@ begin
   end;
 end;
 
-function TANDMR_CCheckBox.GetCornerRadius: Integer;
-begin
-  Result := FBorderSettings.CornerRadius;
-end;
+// function TANDMR_CCheckBox.GetCornerRadius: Integer; // Removed
+// begin
+//   Result := FBorderSettings.CornerRadius;
+// end;
 
-procedure TANDMR_CCheckBox.SetCornerRadius(const Value: Integer);
-begin
-  FBorderSettings.CornerRadius := Value;
-  // FBorderSettings.OnChange will trigger Invalidate via SettingsChanged
-end;
+// procedure TANDMR_CCheckBox.SetCornerRadius(const Value: Integer); // Removed
+// begin
+//   FBorderSettings.CornerRadius := Value;
+// end;
 
 procedure TANDMR_CCheckBox.SetEnabled(Value: Boolean);
 begin
   inherited SetEnabled(Value);
 end;
 
-procedure TANDMR_CCheckBox.SetInternalHoverSettings(const Value: THoverSettings);
+procedure TANDMR_CCheckBox.SetHoverSettings(const Value: THoverSettings); // Renamed
 begin
-  FInternalHoverSettings.Assign(Value);
+  FHoverSettings.Assign(Value); // Renamed
 end;
 
-procedure TANDMR_CCheckBox.SetRoundCornerType(const Value: TRoundCornerType);
-begin
-  FBorderSettings.RoundCornerType := Value;
-  // FBorderSettings.OnChange will trigger Invalidate via SettingsChanged
-end;
+// procedure TANDMR_CCheckBox.SetRoundCornerType(const Value: TRoundCornerType); // Removed
+// begin
+//   FBorderSettings.RoundCornerType := Value;
+// end;
 
-function TANDMR_CCheckBox.GetRoundCornerType: TRoundCornerType;
-begin
-  Result := FBorderSettings.RoundCornerType;
-end;
+// function TANDMR_CCheckBox.GetRoundCornerType: TRoundCornerType; // Removed
+// begin
+//   Result := FBorderSettings.RoundCornerType;
+// end;
 
-function TANDMR_CCheckBox.GetTitleFont: TFont;
-begin
-  Result := FCaptionSettings.Font;
-end;
-
-procedure TANDMR_CCheckBox.SetTitleFont(const Value: TFont);
-begin
-  FCaptionSettings.Font.Assign(Value);
-  // Invalidation is handled by FCaptionSettings.OnChange or its Font.OnChange via SettingsChanged
-end;
+// function TANDMR_CCheckBox.GetTitleFont: TFont; // Removed
+// Removed GetTitleFont, SetTitleFont
 
 procedure TANDMR_CCheckBox.SetTransparent(const Value: Boolean);
 begin

--- a/Source/ANDMR_CEdit.pas
+++ b/Source/ANDMR_CEdit.pas
@@ -46,7 +46,8 @@ type
     procedure SetMaxLength(const Value: Integer);
     procedure SetPasswordChar(const Value: Char);
     procedure SetReadOnly(const Value: Boolean);
-    function GetCornerRadius: Integer;
+    procedure SetBorderSettings(const Value: TBorderSettings); // New
+    (* function GetCornerRadius: Integer;
     procedure SetCornerRadius(const Value: Integer);
     function GetRoundCornerType: TRoundCornerType;
     procedure SetRoundCornerType(const Value: TRoundCornerType);
@@ -57,9 +58,10 @@ type
     function GetBorderThickness: Integer;
     procedure SetBorderThickness(const Value: Integer);
     function GetBorderStyle: TPenStyle;
-    procedure SetBorderStyle(const Value: TPenStyle);
+    procedure SetBorderStyle(const Value: TPenStyle); *)
+    procedure SetImageSettings(const Value: TImageSettings); // New
 
-    function GetImage: TPicture;
+    (* function GetImage: TPicture;
     procedure SetImage(const Value: TPicture);
     function GetImageVisible: Boolean;
     procedure SetImageVisible(const Value: Boolean);
@@ -72,9 +74,10 @@ type
     function GetImagePlacement: TImagePlacement;
     procedure SetImagePlacement(const Value: TImagePlacement);
     function GetImageDrawMode: TImageDrawMode;
-    procedure SetImageDrawMode(const Value: TImageDrawMode);
+    procedure SetImageDrawMode(const Value: TImageDrawMode); *)
+    procedure SetSeparatorSettings(const Value: TSeparatorSettings);
 
-    function GetSeparatorVisible: Boolean;
+    (* function GetSeparatorVisible: Boolean;
     procedure SetSeparatorVisible(const Value: Boolean);
     function GetSeparatorColor: TColor;
     procedure SetSeparatorColor(const Value: TColor);
@@ -85,10 +88,11 @@ type
     function GetSeparatorHeightMode: TSeparatorHeightMode;
     procedure SetSeparatorHeightMode(const Value: TSeparatorHeightMode);
     function GetSeparatorCustomHeight: Integer;
-    procedure SetSeparatorCustomHeight(const Value: Integer);
+    procedure SetSeparatorCustomHeight(const Value: Integer); *)
     procedure CaretTimerTick(Sender: TObject);
+    procedure SetFocusSettings(const Value: TFocusSettings);
 
-    function GetFocusBorderColor: TColor;
+    (* function GetFocusBorderColor: TColor;
     procedure SetFocusBorderColor(const Value: TColor);
     function GetFocusBorderColorVisible: Boolean;
     procedure SetFocusBorderColorVisible(const Value: Boolean);
@@ -103,7 +107,7 @@ type
     function GetFocusUnderlineThickness: Integer;
     procedure SetFocusUnderlineThickness(const Value: Integer);
     function GetFocusUnderlineStyle: TPenStyle;
-    procedure SetFocusUnderlineStyle(const Value: TPenStyle);
+    procedure SetFocusUnderlineStyle(const Value: TPenStyle); *)
     procedure SetOpacity(const Value: Byte);
     procedure SetCurrentCursor(const Value: TCursor);
     procedure SetInputType(const Value: TInputType);
@@ -142,28 +146,31 @@ type
     property MaxLength: Integer read FMaxLength write SetMaxLength default 0;
     property PasswordChar: Char read FPasswordChar write SetPasswordChar default #0;
     property ReadOnly: Boolean read FReadOnly write SetReadOnly default False;
-    property CornerRadius: Integer read GetCornerRadius write SetCornerRadius default 8;
+    property BorderSettings: TBorderSettings read FBorderSettings write SetBorderSettings; // New
+    (* property CornerRadius: Integer read GetCornerRadius write SetCornerRadius default 8;
     property RoundCornerType: TRoundCornerType read GetRoundCornerType write SetRoundCornerType default rctAll;
     property InactiveColor: TColor read GetInactiveColor write SetInactiveColor default clBtnFace; // Delegates to FBorderSettings.BackgroundColor
     property BorderColor: TColor read GetBorderColor write SetBorderColor default clBlack;
     property BorderThickness: Integer read GetBorderThickness write SetBorderThickness default 1;
-    property BorderStyle: TPenStyle read GetBorderStyle write SetBorderStyle default psSolid;
+    property BorderStyle: TPenStyle read GetBorderStyle write SetBorderStyle default psSolid; *)
+    property ImageSettings: TImageSettings read FImageSettings write SetImageSettings; // New
 
-    property Image: TPicture read GetImage write SetImage;
+    (* property Image: TPicture read GetImage write SetImage;
     property ImageVisible: Boolean read GetImageVisible write SetImageVisible default True;
     property ImageMargins: TANDMR_Margins read GetImageMargins write SetImageMargins;
     property ImageDrawMode: TImageDrawMode read GetImageDrawMode write SetImageDrawMode default idmProportional;
 
     property ImagePosition: TImagePositionSide read GetImagePosition write SetImagePosition default ipsLeft;
     property ImageAlignment: TImageAlignmentVertical read GetImageAlignment write SetImageAlignment default iavCenter;
-    property ImagePlacement: TImagePlacement read GetImagePlacement write SetImagePlacement default iplInsideBounds;
+    property ImagePlacement: TImagePlacement read GetImagePlacement write SetImagePlacement default iplInsideBounds; *)
+    property SeparatorSettings: TSeparatorSettings read FSeparatorSettings write SetSeparatorSettings;
 
-    property SeparatorVisible: Boolean read GetSeparatorVisible write SetSeparatorVisible default False;
+    (* property SeparatorVisible: Boolean read GetSeparatorVisible write SetSeparatorVisible default False;
     property SeparatorColor: TColor read GetSeparatorColor write SetSeparatorColor default clGrayText;
     property SeparatorThickness: Integer read GetSeparatorThickness write SetSeparatorThickness default 1;
     property SeparatorPadding: Integer read GetSeparatorPadding write SetSeparatorPadding default 2;
     property SeparatorHeightMode: TSeparatorHeightMode read GetSeparatorHeightMode write SetSeparatorHeightMode default shmFull;
-    property SeparatorCustomHeight: Integer read GetSeparatorCustomHeight write SetSeparatorCustomHeight default 0;
+    property SeparatorCustomHeight: Integer read GetSeparatorCustomHeight write SetSeparatorCustomHeight default 0; *)
 
     property Align;
     property Anchors;
@@ -188,14 +195,15 @@ type
     property OnKeyPress;
     property OnKeyUp;
 
-    property FocusBorderColor: TColor read GetFocusBorderColor write SetFocusBorderColor;
+    property FocusSettings: TFocusSettings read FFocusSettings write SetFocusSettings; // New
+    (* property FocusBorderColor: TColor read GetFocusBorderColor write SetFocusBorderColor;
     property FocusBorderColorVisible: Boolean read GetFocusBorderColorVisible write SetFocusBorderColorVisible;
     property FocusBackgroundColor: TColor read GetFocusBackgroundColor write SetFocusBackgroundColor;
     property FocusBackgroundColorVisible: Boolean read GetFocusBackgroundColorVisible write SetFocusBackgroundColorVisible;
     property FocusUnderlineColor: TColor read GetFocusUnderlineColor write SetFocusUnderlineColor;
     property FocusUnderlineVisible: Boolean read GetFocusUnderlineVisible write SetFocusUnderlineVisible;
     property FocusUnderlineThickness: Integer read GetFocusUnderlineThickness write SetFocusUnderlineThickness;
-    property FocusUnderlineStyle: TPenStyle read GetFocusUnderlineStyle write SetFocusUnderlineStyle;
+    property FocusUnderlineStyle: TPenStyle read GetFocusUnderlineStyle write SetFocusUnderlineStyle; *)
     property Opacity: Byte read FOpacity write SetOpacity;
     property CurrentCursor: TCursor read FCurrentCursor write SetCurrentCursor;
     property InputType: TInputType read FInputType write SetInputType default itNormal;
@@ -449,8 +457,14 @@ end;
 
 procedure TANDMR_CEdit.SetReadOnly(const Value: Boolean); begin if FReadOnly <> Value then begin FReadOnly := Value; Invalidate; end; end;
 
-// Getters and Setters for Border Properties
-function TANDMR_CEdit.GetCornerRadius: Integer; begin Result := FBorderSettings.CornerRadius; end;
+procedure TANDMR_CEdit.SetBorderSettings(const Value: TBorderSettings);
+begin
+  FBorderSettings.Assign(Value);
+  Invalidate;
+end;
+
+// Getters and Setters for Border Properties - To be removed
+(* function TANDMR_CEdit.GetCornerRadius: Integer; begin Result := FBorderSettings.CornerRadius; end;
 procedure TANDMR_CEdit.SetCornerRadius(const Value: Integer); begin FBorderSettings.CornerRadius := Value; end;
 function TANDMR_CEdit.GetRoundCornerType: TRoundCornerType; begin Result := FBorderSettings.RoundCornerType; end;
 procedure TANDMR_CEdit.SetRoundCornerType(const Value: TRoundCornerType); begin FBorderSettings.RoundCornerType := Value; end;
@@ -461,7 +475,7 @@ procedure TANDMR_CEdit.SetBorderColor(const Value: TColor); begin FBorderSetting
 function TANDMR_CEdit.GetBorderThickness: Integer; begin Result := FBorderSettings.Thickness; end;
 procedure TANDMR_CEdit.SetBorderThickness(const Value: Integer); begin FBorderSettings.Thickness := Value; end;
 function TANDMR_CEdit.GetBorderStyle: TPenStyle; begin Result := FBorderSettings.Style; end;
-procedure TANDMR_CEdit.SetBorderStyle(const Value: TPenStyle); begin FBorderSettings.Style := Value; end;
+procedure TANDMR_CEdit.SetBorderStyle(const Value: TPenStyle); begin FBorderSettings.Style := Value; end; *)
 
 procedure TANDMR_CEdit.SettingsChanged(Sender: TObject);
 begin
@@ -473,7 +487,13 @@ begin
   Invalidate;
 end;
 
-function TANDMR_CEdit.GetImage: TPicture;
+procedure TANDMR_CEdit.SetImageSettings(const Value: TImageSettings);
+begin
+  FImageSettings.Assign(Value);
+  Invalidate; // Or call ImageSettingsChanged if more logic is needed
+end;
+
+(* function TANDMR_CEdit.GetImage: TPicture;
 begin
   Result := FImageSettings.Picture;
 end;
@@ -519,10 +539,16 @@ procedure TANDMR_CEdit.SetImagePosition(const Value: TImagePositionSide); begin 
 function TANDMR_CEdit.GetImageAlignment: TImageAlignmentVertical; begin Result := FImageSettings.AlignmentVertical; end;
 procedure TANDMR_CEdit.SetImageAlignment(const Value: TImageAlignmentVertical); begin FImageSettings.AlignmentVertical := Value; end;
 function TANDMR_CEdit.GetImagePlacement: TImagePlacement; begin Result := FImageSettings.Placement; end;
-procedure TANDMR_CEdit.SetImagePlacement(const Value: TImagePlacement); begin FImageSettings.Placement := Value; end;
+procedure TANDMR_CEdit.SetImagePlacement(const Value: TImagePlacement); begin FImageSettings.Placement := Value; end; *)
 
-// Getters and Setters for Separator Properties
-function TANDMR_CEdit.GetSeparatorVisible: Boolean; begin Result := FSeparatorSettings.Visible; end;
+procedure TANDMR_CEdit.SetSeparatorSettings(const Value: TSeparatorSettings);
+begin
+  FSeparatorSettings.Assign(Value);
+  Invalidate;
+end;
+
+// Getters and Setters for Separator Properties - To be removed
+(* function TANDMR_CEdit.GetSeparatorVisible: Boolean; begin Result := FSeparatorSettings.Visible; end;
 procedure TANDMR_CEdit.SetSeparatorVisible(const Value: Boolean); begin FSeparatorSettings.Visible := Value; end;
 function TANDMR_CEdit.GetSeparatorColor: TColor; begin Result := FSeparatorSettings.Color; end;
 procedure TANDMR_CEdit.SetSeparatorColor(const Value: TColor); begin FSeparatorSettings.Color := Value; end;
@@ -533,12 +559,18 @@ procedure TANDMR_CEdit.SetSeparatorPadding(const Value: Integer); begin FSeparat
 function TANDMR_CEdit.GetSeparatorHeightMode: TSeparatorHeightMode; begin Result := FSeparatorSettings.HeightMode; end;
 procedure TANDMR_CEdit.SetSeparatorHeightMode(const Value: TSeparatorHeightMode); begin FSeparatorSettings.HeightMode := Value; end;
 function TANDMR_CEdit.GetSeparatorCustomHeight: Integer; begin Result := FSeparatorSettings.CustomHeight; end;
-procedure TANDMR_CEdit.SetSeparatorCustomHeight(const Value: Integer); begin FSeparatorSettings.CustomHeight := Value; end;
+procedure TANDMR_CEdit.SetSeparatorCustomHeight(const Value: Integer); begin FSeparatorSettings.CustomHeight := Value; end; *)
 
 procedure TANDMR_CEdit.CaretTimerTick(Sender: TObject); begin if Focused then begin FCaretVisible := not FCaretVisible; Invalidate; end else begin FCaretVisible := False; FCaretTimer.Enabled := False; Invalidate; end; end;
 
-// Getters and Setters for Focus Properties
-function TANDMR_CEdit.GetFocusBorderColor: TColor; begin Result := FFocusSettings.BorderColor; end;
+procedure TANDMR_CEdit.SetFocusSettings(const Value: TFocusSettings);
+begin
+  FFocusSettings.Assign(Value);
+  Invalidate;
+end;
+
+// Getters and Setters for Focus Properties - To be removed
+(* function TANDMR_CEdit.GetFocusBorderColor: TColor; begin Result := FFocusSettings.BorderColor; end;
 procedure TANDMR_CEdit.SetFocusBorderColor(const Value: TColor); begin FFocusSettings.BorderColor := Value; end;
 function TANDMR_CEdit.GetFocusBorderColorVisible: Boolean; begin Result := FFocusSettings.BorderColorVisible; end;
 procedure TANDMR_CEdit.SetFocusBorderColorVisible(const Value: Boolean); begin FFocusSettings.BorderColorVisible := Value; end;
@@ -553,7 +585,7 @@ procedure TANDMR_CEdit.SetFocusUnderlineVisible(const Value: Boolean); begin FFo
 function TANDMR_CEdit.GetFocusUnderlineThickness: Integer; begin Result := FFocusSettings.UnderlineThickness; end;
 procedure TANDMR_CEdit.SetFocusUnderlineThickness(const Value: Integer); begin FFocusSettings.UnderlineThickness := Value; end;
 function TANDMR_CEdit.GetFocusUnderlineStyle: TPenStyle; begin Result := FFocusSettings.UnderlineStyle; end;
-procedure TANDMR_CEdit.SetFocusUnderlineStyle(const Value: TPenStyle); begin FFocusSettings.UnderlineStyle := Value; end;
+procedure TANDMR_CEdit.SetFocusUnderlineStyle(const Value: TPenStyle); begin FFocusSettings.UnderlineStyle := Value; end; *)
 procedure TANDMR_CEdit.SetOpacity(const Value: Byte); begin if FOpacity <> Value then begin FOpacity := Value; if FOpacity < 255 then begin ControlStyle := ControlStyle - [csOpaque]; if Parent <> nil then Parent.Invalidate; end else begin ControlStyle := ControlStyle + [csOpaque]; end; Invalidate; end; end;
 procedure TANDMR_CEdit.SetCurrentCursor(const Value: TCursor); begin if FCurrentCursor <> Value then begin FCurrentCursor := Value; Self.Cursor := FCurrentCursor; end; end;
 procedure TANDMR_CEdit.SetInputType(const Value: TInputType); begin if FInputType <> Value then begin FInputType := Value; end; end;

--- a/Source/ANDMR_CMemo.pas
+++ b/Source/ANDMR_CMemo.pas
@@ -5,30 +5,26 @@ interface
 uses
   System.SysUtils, System.Classes, Vcl.Controls, Vcl.Graphics, Winapi.Windows,
   Vcl.StdCtrls, System.UITypes, Winapi.Messages, Vcl.Forms, Vcl.Themes,
-  ANDMR_ComponentUtils, // Already includes System.Types for TPoint
+  ANDMR_ComponentUtils,
   Winapi.GDIPOBJ, Winapi.GDIPAPI, Winapi.GDIPUTIL, Vcl.Imaging.pngimage,
   System.Math;
 
 type
   TANDMR_CMemo = class(TCustomControl)
   private
-    // New Settings Objects
     FBorderSettings: TBorderSettings;
     FFocusSettings: TFocusSettings;
     FSeparatorSettings: TSeparatorSettings;
-    FImageSettings: TImageSettings; // Contains Picture, Margins, etc.
+    FImageSettings: TImageSettings;
     FCaptionSettings: TCaptionSettings;
     FHoverSettings: THoverSettings;
     FTextMargins: TANDMR_Margins;
 
-    // Fields specific to TANDMR_CMemo or retained temporarily
     FCaptionRect: TRect;
     FHovered: Boolean;
-
     FOpacity: Byte;
     FInternalMemo: TMemo;
 
-    // Event Fields
     FOnChange: TNotifyEvent;
     FOnEnter: TNotifyEvent;
     FOnExit: TNotifyEvent;
@@ -36,7 +32,6 @@ type
     FOnKeyPress: TKeyPressEvent;
     FOnKeyUp: TKeyEvent;
 
-    // Getter/Setter Declarations for Memo Properties
     function GetLines: TStrings;
     procedure SetLines(const Value: TStrings);
     function GetReadOnly: Boolean;
@@ -48,77 +43,20 @@ type
     function GetMaxLength: Integer;
     procedure SetMaxLength(const Value: Integer);
 
-    // Getters/Setters for Appearance Properties (delegating to settings objects)
-    function GetCornerRadius: Integer;
-    procedure SetCornerRadius(const Value: Integer);
-    function GetRoundCornerType: TRoundCornerType;
-    procedure SetRoundCornerType(const Value: TRoundCornerType);
-    function GetInactiveColor: TColor;
-    procedure SetInactiveColor(const Value: TColor);
-    function GetBorderColor: TColor;
-    procedure SetBorderColor(const Value: TColor);
-    function GetBorderThickness: Integer;
-    procedure SetBorderThickness(const Value: Integer);
-    function GetBorderStyle: TPenStyle;
-    procedure SetBorderStyle(const Value: TPenStyle);
-
-    function GetImage: TPicture;
-    procedure SetImage(const Value: TPicture);
-    function GetImageVisible: Boolean;
-    procedure SetImageVisible(const Value: Boolean);
-    function GetImagePosition: TImagePositionSide;
-    procedure SetImagePosition(const Value: TImagePositionSide);
-    function GetImageAlignment: TImageAlignmentVertical;
-    procedure SetImageAlignment(const Value: TImageAlignmentVertical);
-    function GetImageMargins: TANDMR_Margins;
-    procedure SetImageMargins(const Value: TANDMR_Margins);
-    function GetImagePlacement: TImagePlacement;
-    procedure SetImagePlacement(const Value: TImagePlacement);
-    function GetImageDrawMode: TImageDrawMode;
-    procedure SetImageDrawMode(const Value: TImageDrawMode);
-
-    function GetSeparatorVisible: Boolean;
-    procedure SetSeparatorVisible(const Value: Boolean);
-    function GetSeparatorColor: TColor;
-    procedure SetSeparatorColor(const Value: TColor);
-    function GetSeparatorThickness: Integer;
-    procedure SetSeparatorThickness(const Value: Integer);
-    function GetSeparatorPadding: Integer;
-    procedure SetSeparatorPadding(const Value: Integer);
-    function GetSeparatorHeightMode: TSeparatorHeightMode;
-    procedure SetSeparatorHeightMode(const Value: TSeparatorHeightMode);
-    function GetSeparatorCustomHeight: Integer;
-    procedure SetSeparatorCustomHeight(const Value: Integer);
-
+    procedure SetBorderSettings(const Value: TBorderSettings);
+    procedure SetFocusSettings(const Value: TFocusSettings);
+    procedure SetSeparatorSettings(const Value: TSeparatorSettings);
+    procedure SetImageSettings(const Value: TImageSettings);
     procedure SetCaptionSettings(const Value: TCaptionSettings);
     procedure SetHoverSettings(const Value: THoverSettings);
     procedure SetTextMargins(const Value: TANDMR_Margins);
-
-    function GetFocusBorderColor: TColor;
-    procedure SetFocusBorderColor(const Value: TColor);
-    function GetFocusBorderColorVisible: Boolean;
-    procedure SetFocusBorderColorVisible(const Value: Boolean);
-    function GetFocusBackgroundColor: TColor;
-    procedure SetFocusBackgroundColor(const Value: TColor);
-    function GetFocusBackgroundColorVisible: Boolean;
-    procedure SetFocusBackgroundColorVisible(const Value: Boolean);
-    function GetFocusUnderlineColor: TColor;
-    procedure SetFocusUnderlineColor(const Value: TColor);
-    function GetFocusUnderlineVisible: Boolean;
-    procedure SetFocusUnderlineVisible(const Value: Boolean);
-    function GetFocusUnderlineThickness: Integer;
-    procedure SetFocusUnderlineThickness(const Value: Integer);
-    function GetFocusUnderlineStyle: TPenStyle;
-    procedure SetFocusUnderlineStyle(const Value: TPenStyle);
     procedure SetOpacity(const Value: Byte);
 
-    // Event Handlers for Settings Objects
     procedure SettingsChanged(Sender: TObject);
     procedure CaptionSettingsChanged(Sender: TObject);
     procedure HoverSettingsChanged(Sender: TObject);
     procedure TextMarginsChanged(Sender: TObject);
 
-    // Internal Memo Event Handlers (Delegates)
     procedure InternalMemoChange(Sender: TObject);
     procedure InternalMemoEnter(Sender: TObject);
     procedure InternalMemoExit(Sender: TObject);
@@ -127,7 +65,6 @@ type
     procedure InternalMemoKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
 
   protected
-    // Control Message Handlers
     procedure CMEnter(var Message: TCMEnter); message CM_ENTER;
     procedure CMExit(var Message: TCMExit); message CM_EXIT;
     procedure CMMouseEnter(var Message: TMessage); message CM_MOUSEENTER;
@@ -146,52 +83,22 @@ type
     procedure Paint; override;
     procedure MouseDown(Button: TMouseButton; Shift: TShiftState; X, Y: Integer); override;
   published
-    // Core Memo Properties
     property Lines: TStrings read GetLines write SetLines;
     property ReadOnly: Boolean read GetReadOnly write SetReadOnly default False;
     property WordWrap: Boolean read GetWordWrap write SetWordWrap default True;
     property ScrollBars: TScrollStyle read GetScrollBars write SetScrollBars default ssVertical;
     property MaxLength: Integer read GetMaxLength write SetMaxLength default 0;
 
-    // Appearance Properties
-    property CornerRadius: Integer read GetCornerRadius write SetCornerRadius default 8;
-    property RoundCornerType: TRoundCornerType read GetRoundCornerType write SetRoundCornerType default rctAll;
-    property InactiveColor: TColor read GetInactiveColor write SetInactiveColor default clBtnFace;
-    property BorderColor: TColor read GetBorderColor write SetBorderColor default clBlack;
-    property BorderThickness: Integer read GetBorderThickness write SetBorderThickness default 1;
-    property BorderStyle: TPenStyle read GetBorderStyle write SetBorderStyle default psSolid;
-
-    property Image: TPicture read GetImage write SetImage;
-    property ImageVisible: Boolean read GetImageVisible write SetImageVisible default True;
-    property ImagePosition: TImagePositionSide read GetImagePosition write SetImagePosition default ipsLeft;
-    property ImageAlignment: TImageAlignmentVertical read GetImageAlignment write SetImageAlignment default iavCenter;
-    property ImageMargins: TANDMR_Margins read GetImageMargins write SetImageMargins;
-    property ImagePlacement: TImagePlacement read GetImagePlacement write SetImagePlacement default iplInsideBounds;
-    property ImageDrawMode: TImageDrawMode read GetImageDrawMode write SetImageDrawMode default idmProportional;
-
-    property SeparatorVisible: Boolean read GetSeparatorVisible write SetSeparatorVisible default False;
-    property SeparatorColor: TColor read GetSeparatorColor write SetSeparatorColor default clGrayText;
-    property SeparatorThickness: Integer read GetSeparatorThickness write SetSeparatorThickness default 1;
-    property SeparatorPadding: Integer read GetSeparatorPadding write SetSeparatorPadding default 2;
-    property SeparatorHeightMode: TSeparatorHeightMode read GetSeparatorHeightMode write SetSeparatorHeightMode default shmFull;
-    property SeparatorCustomHeight: Integer read GetSeparatorCustomHeight write SetSeparatorCustomHeight default 0;
-
+    property BorderSettings: TBorderSettings read FBorderSettings write SetBorderSettings;
+    property FocusSettings: TFocusSettings read FFocusSettings write SetFocusSettings;
+    property SeparatorSettings: TSeparatorSettings read FSeparatorSettings write SetSeparatorSettings;
+    property ImageSettings: TImageSettings read FImageSettings write SetImageSettings;
     property CaptionSettings: TCaptionSettings read FCaptionSettings write SetCaptionSettings;
     property HoverSettings: THoverSettings read FHoverSettings write SetHoverSettings;
     property TextMargins: TANDMR_Margins read FTextMargins write SetTextMargins;
 
-    property FocusBorderColor: TColor read GetFocusBorderColor write SetFocusBorderColor;
-    property FocusBorderColorVisible: Boolean read GetFocusBorderColorVisible write SetFocusBorderColorVisible;
-    property FocusBackgroundColor: TColor read GetFocusBackgroundColor write SetFocusBackgroundColor;
-    property FocusBackgroundColorVisible: Boolean read GetFocusBackgroundColorVisible write SetFocusBackgroundColorVisible;
-    property FocusUnderlineColor: TColor read GetFocusUnderlineColor write SetFocusUnderlineColor;
-    property FocusUnderlineVisible: Boolean read GetFocusUnderlineVisible write SetFocusUnderlineVisible;
-    property FocusUnderlineThickness: Integer read GetFocusUnderlineThickness write SetFocusUnderlineThickness;
-    property FocusUnderlineStyle: TPenStyle read GetFocusUnderlineStyle write SetFocusUnderlineStyle;
-
     property Opacity: Byte read FOpacity write SetOpacity default 255;
 
-    // Standard Properties
     property Align;
     property Anchors;
     property Constraints;
@@ -204,7 +111,6 @@ type
     property TabStop default True;
     property Visible;
 
-    // Standard Event Properties
     property OnChange: TNotifyEvent read FOnChange write FOnChange;
     property OnEnter: TNotifyEvent read FOnEnter write FOnEnter;
     property OnExit: TNotifyEvent read FOnExit write FOnExit;
@@ -244,8 +150,8 @@ begin
 
   FFocusSettings := TFocusSettings.Create;
   FFocusSettings.OnChange := SettingsChanged;
-  FFocusSettings.BorderColorVisible := True; // Changed
-  FFocusSettings.BorderColor := clHighlight; // Changed
+  FFocusSettings.BorderColorVisible := True;
+  FFocusSettings.BorderColor := clHighlight;
   FFocusSettings.BackgroundColorVisible := False;
   FFocusSettings.BackgroundColor := clWindow;
   FFocusSettings.UnderlineVisible := False;
@@ -263,7 +169,7 @@ begin
   FSeparatorSettings.CustomHeight := 0;
 
   FImageSettings := TImageSettings.Create(Self);
-  FImageSettings.OnChange := SettingsChanged;
+  FImageSettings.OnChange := SettingsChanged; // Ensure this calls the general SettingsChanged
   FImageSettings.Visible := True;
   FImageSettings.Position := ipsLeft;
   FImageSettings.AlignmentVertical := iavCenter;
@@ -336,7 +242,7 @@ end;
 
 procedure TANDMR_CMemo.SettingsChanged(Sender: TObject);
 begin
-  if (ComponentState * [csLoading, csReading, csDesigning]) <> [] then // Corrected set elements
+  if (ComponentState * [csLoading, csReading, csDesigning]) <> [] then
   begin
     Invalidate;
     Exit;
@@ -350,7 +256,7 @@ end;
 
 procedure TANDMR_CMemo.CaptionSettingsChanged(Sender: TObject);
 begin
-  if (ComponentState * [csLoading, csReading, csDesigning]) <> [] then // Corrected set elements
+  if (ComponentState * [csLoading, csReading, csDesigning]) <> [] then
   begin
     Invalidate;
     Exit;
@@ -369,7 +275,7 @@ end;
 
 procedure TANDMR_CMemo.TextMarginsChanged(Sender: TObject);
 begin
-  if (ComponentState * [csLoading, csReading, csDesigning]) <> [] then // Corrected set elements
+  if (ComponentState * [csLoading, csReading, csDesigning]) <> [] then
   begin
     Invalidate;
     Exit;
@@ -414,67 +320,47 @@ begin
   if Assigned(FOnKeyUp) then FOnKeyUp(Self, Key, Shift);
 end;
 
-function TANDMR_CMemo.GetCornerRadius: Integer; begin Result := FBorderSettings.CornerRadius; end;
-procedure TANDMR_CMemo.SetCornerRadius(const Value: Integer); begin FBorderSettings.CornerRadius := Value; end;
-function TANDMR_CMemo.GetRoundCornerType: TRoundCornerType; begin Result := FBorderSettings.RoundCornerType; end;
-procedure TANDMR_CMemo.SetRoundCornerType(const Value: TRoundCornerType); begin FBorderSettings.RoundCornerType := Value; end;
-function TANDMR_CMemo.GetInactiveColor: TColor; begin Result := FBorderSettings.BackgroundColor; end;
-procedure TANDMR_CMemo.SetInactiveColor(const Value: TColor); begin FBorderSettings.BackgroundColor := Value; end;
-function TANDMR_CMemo.GetBorderColor: TColor; begin Result := FBorderSettings.Color; end;
-procedure TANDMR_CMemo.SetBorderColor(const Value: TColor); begin FBorderSettings.Color := Value; end;
-function TANDMR_CMemo.GetBorderThickness: Integer; begin Result := FBorderSettings.Thickness; end;
-procedure TANDMR_CMemo.SetBorderThickness(const Value: Integer); begin FBorderSettings.Thickness := Value; end;
-function TANDMR_CMemo.GetBorderStyle: TPenStyle; begin Result := FBorderSettings.Style; end;
-procedure TANDMR_CMemo.SetBorderStyle(const Value: TPenStyle); begin FBorderSettings.Style := Value; end;
+procedure TANDMR_CMemo.SetBorderSettings(const Value: TBorderSettings);
+begin
+  FBorderSettings.Assign(Value);
+  SettingsChanged(Self);
+end;
 
-function TANDMR_CMemo.GetImage: TPicture; begin Result := FImageSettings.Picture; end;
-procedure TANDMR_CMemo.SetImage(const Value: TPicture); begin FImageSettings.Picture.Assign(Value); end;
-function TANDMR_CMemo.GetImageVisible: Boolean; begin Result := FImageSettings.Visible; end;
-procedure TANDMR_CMemo.SetImageVisible(const Value: Boolean); begin FImageSettings.Visible := Value; end;
-function TANDMR_CMemo.GetImagePosition: TImagePositionSide; begin Result := FImageSettings.Position; end;
-procedure TANDMR_CMemo.SetImagePosition(const Value: TImagePositionSide); begin FImageSettings.Position := Value; end;
-function TANDMR_CMemo.GetImageAlignment: TImageAlignmentVertical; begin Result := FImageSettings.AlignmentVertical; end;
-procedure TANDMR_CMemo.SetImageAlignment(const Value: TImageAlignmentVertical); begin FImageSettings.AlignmentVertical := Value; end;
-function TANDMR_CMemo.GetImageMargins: TANDMR_Margins; begin Result := FImageSettings.Margins; end;
-procedure TANDMR_CMemo.SetImageMargins(const Value: TANDMR_Margins); begin FImageSettings.Margins.Assign(Value); end;
-function TANDMR_CMemo.GetImagePlacement: TImagePlacement; begin Result := FImageSettings.Placement; end;
-procedure TANDMR_CMemo.SetImagePlacement(const Value: TImagePlacement); begin FImageSettings.Placement := Value; end;
-function TANDMR_CMemo.GetImageDrawMode: TImageDrawMode; begin Result := FImageSettings.DrawMode; end;
-procedure TANDMR_CMemo.SetImageDrawMode(const Value: TImageDrawMode); begin FImageSettings.DrawMode := Value; end;
+procedure TANDMR_CMemo.SetImageSettings(const Value: TImageSettings);
+begin
+  FImageSettings.Assign(Value);
+  SettingsChanged(Self);
+end;
 
-function TANDMR_CMemo.GetSeparatorVisible: Boolean; begin Result := FSeparatorSettings.Visible; end;
-procedure TANDMR_CMemo.SetSeparatorVisible(const Value: Boolean); begin FSeparatorSettings.Visible := Value; end;
-function TANDMR_CMemo.GetSeparatorColor: TColor; begin Result := FSeparatorSettings.Color; end;
-procedure TANDMR_CMemo.SetSeparatorColor(const Value: TColor); begin FSeparatorSettings.Color := Value; end;
-function TANDMR_CMemo.GetSeparatorThickness: Integer; begin Result := FSeparatorSettings.Thickness; end;
-procedure TANDMR_CMemo.SetSeparatorThickness(const Value: Integer); begin FSeparatorSettings.Thickness := Value; end;
-function TANDMR_CMemo.GetSeparatorPadding: Integer; begin Result := FSeparatorSettings.Padding; end;
-procedure TANDMR_CMemo.SetSeparatorPadding(const Value: Integer); begin FSeparatorSettings.Padding := Value; end;
-function TANDMR_CMemo.GetSeparatorHeightMode: TSeparatorHeightMode; begin Result := FSeparatorSettings.HeightMode; end;
-procedure TANDMR_CMemo.SetSeparatorHeightMode(const Value: TSeparatorHeightMode); begin FSeparatorSettings.HeightMode := Value; end;
-function TANDMR_CMemo.GetSeparatorCustomHeight: Integer; begin Result := FSeparatorSettings.CustomHeight; end;
-procedure TANDMR_CMemo.SetSeparatorCustomHeight(const Value: Integer); begin FSeparatorSettings.CustomHeight := Value; end;
+procedure TANDMR_CMemo.SetSeparatorSettings(const Value: TSeparatorSettings);
+begin
+  FSeparatorSettings.Assign(Value);
+  SettingsChanged(Self);
+end;
 
-procedure TANDMR_CMemo.SetCaptionSettings(const Value: TCaptionSettings); begin FCaptionSettings.Assign(Value); end;
-procedure TANDMR_CMemo.SetHoverSettings(const Value: THoverSettings); begin FHoverSettings.Assign(Value); end;
-procedure TANDMR_CMemo.SetTextMargins(const Value: TANDMR_Margins); begin FTextMargins.Assign(Value); end;
+procedure TANDMR_CMemo.SetCaptionSettings(const Value: TCaptionSettings);
+begin
+  FCaptionSettings.Assign(Value);
+  CaptionSettingsChanged(Self);
+end;
 
-function TANDMR_CMemo.GetFocusBorderColor: TColor; begin Result := FFocusSettings.BorderColor; end;
-procedure TANDMR_CMemo.SetFocusBorderColor(const Value: TColor); begin FFocusSettings.BorderColor := Value; end;
-function TANDMR_CMemo.GetFocusBorderColorVisible: Boolean; begin Result := FFocusSettings.BorderColorVisible; end;
-procedure TANDMR_CMemo.SetFocusBorderColorVisible(const Value: Boolean); begin FFocusSettings.BorderColorVisible := Value; end;
-function TANDMR_CMemo.GetFocusBackgroundColor: TColor; begin Result := FFocusSettings.BackgroundColor; end;
-procedure TANDMR_CMemo.SetFocusBackgroundColor(const Value: TColor); begin FFocusSettings.BackgroundColor := Value; end;
-function TANDMR_CMemo.GetFocusBackgroundColorVisible: Boolean; begin Result := FFocusSettings.BackgroundColorVisible; end;
-procedure TANDMR_CMemo.SetFocusBackgroundColorVisible(const Value: Boolean); begin FFocusSettings.BackgroundColorVisible := Value; end;
-function TANDMR_CMemo.GetFocusUnderlineColor: TColor; begin Result := FFocusSettings.UnderlineColor; end;
-procedure TANDMR_CMemo.SetFocusUnderlineColor(const Value: TColor); begin FFocusSettings.UnderlineColor := Value; end;
-function TANDMR_CMemo.GetFocusUnderlineVisible: Boolean; begin Result := FFocusSettings.UnderlineVisible; end;
-procedure TANDMR_CMemo.SetFocusUnderlineVisible(const Value: Boolean); begin FFocusSettings.UnderlineVisible := Value; end;
-function TANDMR_CMemo.GetFocusUnderlineThickness: Integer; begin Result := FFocusSettings.UnderlineThickness; end;
-procedure TANDMR_CMemo.SetFocusUnderlineThickness(const Value: Integer); begin FFocusSettings.UnderlineThickness := Value; end;
-function TANDMR_CMemo.GetFocusUnderlineStyle: TPenStyle; begin Result := FFocusSettings.UnderlineStyle; end;
-procedure TANDMR_CMemo.SetFocusUnderlineStyle(const Value: TPenStyle); begin FFocusSettings.UnderlineStyle := Value; end;
+procedure TANDMR_CMemo.SetHoverSettings(const Value: THoverSettings);
+begin
+  FHoverSettings.Assign(Value);
+  HoverSettingsChanged(Self); // Call HoverSettingsChanged
+end;
+
+procedure TANDMR_CMemo.SetTextMargins(const Value: TANDMR_Margins);
+begin
+  FTextMargins.Assign(Value);
+  TextMarginsChanged(Self);
+end;
+
+procedure TANDMR_CMemo.SetFocusSettings(const Value: TFocusSettings);
+begin
+  FFocusSettings.Assign(Value);
+  SettingsChanged(Self);
+end;
 
 procedure TANDMR_CMemo.SetOpacity(const Value: Byte);
 begin
@@ -546,13 +432,13 @@ end;
 
 procedure TANDMR_CMemo.CMFontChanged(var Message: TMessage);
 begin
-  inherited; // Call the inherited CM_FONTCHANGED handler
+  inherited;
   if Assigned(FInternalMemo) then
   begin
-    FInternalMemo.Font.Assign(Self.Font); // Propagate the change to the internal memo
+    FInternalMemo.Font.Assign(Self.Font);
   end;
-  UpdateInternalMemoBounds; // Font changes can affect layout
-  Invalidate; // Repaint the entire component
+  UpdateInternalMemoBounds;
+  Invalidate;
 end;
 
 procedure TANDMR_CMemo.CalculateLayout(out outImgRect: TRect; out outTxtRect: TRect; out outSepRect: TRect);
@@ -570,10 +456,10 @@ var
   tempW, tempH: Double;
   EffectiveCaptionOffsetX, EffectiveCaptionOffsetY: Integer;
 begin
-  if not HandleAllocated then // Guard against operations requiring a handle
+  if not HandleAllocated then
   begin
     outImgRect := Rect(0,0,0,0);
-    outTxtRect := Rect(0, 0, Width, Height); // Use Width/Height as a fallback
+    outTxtRect := Rect(0, 0, Width, Height);
     outSepRect := Rect(0,0,0,0);
     Exit;
   end;
@@ -914,7 +800,7 @@ begin
 
       var FocusFrameBG, FocusBorderColor, FocusMemoBG, FocusMemoFontColor, FocusCaptionColor: TColor;
       FocusFrameBG := clNone;
-      FocusBorderColor := FFocusSettings.BorderColor; // Changed: FActiveColor removed, ResolveStateColor handles visibility
+      FocusBorderColor := FFocusSettings.BorderColor;
       FocusMemoBG := IfThen(FFocusSettings.BackgroundColorVisible, FFocusSettings.BackgroundColor, clNone);
       FocusMemoFontColor := BaseMemoFontColor;
       FocusCaptionColor := BaseCaptionColor;

--- a/Source/ANDMR_CPanel.pas
+++ b/Source/ANDMR_CPanel.pas
@@ -31,42 +31,10 @@ type
     FIsHovering: Boolean;
 
     // Property Getters/Setters
-    function GetColor: TColor;
-    procedure SetColor(const Value: TColor);
-    function GetBorderColor: TColor;
-    procedure SetBorderColor(const Value: TColor);
-    function GetBorderThickness: Integer;
-    procedure SetBorderThickness(const Value: Integer);
-    function GetBorderStyle: TPenStyle;
-    procedure SetBorderStyle(const Value: TPenStyle);
-    function GetCornerRadius: Integer;
-    procedure SetCornerRadius(const Value: Integer);
-    function GetRoundCornerType: TRoundCornerType;
-    procedure SetRoundCornerType(const Value: TRoundCornerType);
-    function GetCaption: string;
-    procedure SetCaption(const Value: string);
-    // GetFont and SetFont are now in protected
-    function GetDropShadowEnabled: Boolean;
-    procedure SetDropShadowEnabled(const Value: Boolean);
-    function GetDropShadowColor: TColor;
-    procedure SetDropShadowColor(const Value: TColor);
-    function GetDropShadowOffset: TPoint;
-    procedure SetDropShadowOffset(const Value: TPoint);
-    function GetDropShadowBlurRadius: Integer;
-    procedure SetDropShadowBlurRadius(const Value: Integer);
+    procedure SetBorderSettings(const Value: TBorderSettings);
+    procedure SetCaptionSettings(const Value: TCaptionSettings);
+    procedure SetDropShadowSettings(const Value: TDropShadowSettings);
     procedure SetOpacity(const Value: Byte);
-    function GetCaptionAlignment: System.Classes.TAlignment;
-    procedure SetCaptionAlignment(const Value: System.Classes.TAlignment);
-    function GetCaptionVerticalAlignment: TCaptionVerticalAlignment;
-    procedure SetCaptionVerticalAlignment(const Value: TCaptionVerticalAlignment);
-    function GetCaptionWordWrap: Boolean;
-    procedure SetCaptionWordWrap(const Value: Boolean);
-    function GetCaptionOffsetX: Integer;
-    procedure SetCaptionOffsetX(const Value: Integer);
-    function GetCaptionOffsetY: Integer;
-    procedure SetCaptionOffsetY(const Value: Integer);
-    function GetDisabledFontColor: TColor;
-    procedure SetDisabledFontColor(const Value: TColor);
     procedure SetTransparentChildren(const Value: Boolean);
     procedure SetHoverSettings(const Value: THoverSettings);
 
@@ -83,35 +51,36 @@ type
     procedure Loaded; override;
     procedure Resize; override;
     procedure CreateWnd; override;
-    function GetFont: TFont; // Getter for published Font property
-    procedure SetFont(Value: TFont);   // Removed 'override'
 
   public
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
 
   published
-    property Color: TColor read GetColor write SetColor default clBtnFace;
+    property BorderSettings: TBorderSettings read FBorderSettings write SetBorderSettings; // New
+    (* property Color: TColor read GetColor write SetColor default clBtnFace;
     property BorderColor: TColor read GetBorderColor write SetBorderColor default clBlack;
     property BorderThickness: Integer read GetBorderThickness write SetBorderThickness default 1;
     property BorderStyle: TPenStyle read GetBorderStyle write SetBorderStyle default psSolid;
     property CornerRadius: Integer read GetCornerRadius write SetCornerRadius default 0;
-    property RoundCornerType: TRoundCornerType read GetRoundCornerType write SetRoundCornerType default rctNone;
-    property Caption: string read GetCaption write SetCaption;
+    property RoundCornerType: TRoundCornerType read GetRoundCornerType write SetRoundCornerType default rctNone; *)
+    property CaptionSettings: TCaptionSettings read FCaptionSettings write SetCaptionSettings; // New
+    (* property Caption: string read GetCaption write SetCaption;
     property CaptionAlignment: System.Classes.TAlignment read GetCaptionAlignment write SetCaptionAlignment default taCenter;
     property CaptionVerticalAlignment: TCaptionVerticalAlignment read GetCaptionVerticalAlignment write SetCaptionVerticalAlignment default cvaCenter;
     property CaptionWordWrap: Boolean read GetCaptionWordWrap write SetCaptionWordWrap default False;
     property CaptionOffsetX: Integer read GetCaptionOffsetX write SetCaptionOffsetX default 0;
     property CaptionOffsetY: Integer read GetCaptionOffsetY write SetCaptionOffsetY default 0;
     property DisabledFontColor: TColor read GetDisabledFontColor write SetDisabledFontColor default clGrayText;
-    property Font: TFont read GetFont write SetFont;
+    property Font: TFont read GetFont write SetFont; *)
     property TransparentChildren: Boolean read FTransparentChildren write SetTransparentChildren default False;
     property HoverSettings: THoverSettings read FHoverSettings write SetHoverSettings;
+    property DropShadowSettings: TDropShadowSettings read FDropShadowSettings write SetDropShadowSettings; // New
 
-    property DropShadowEnabled: Boolean read GetDropShadowEnabled write SetDropShadowEnabled default False;
+    (* property DropShadowEnabled: Boolean read GetDropShadowEnabled write SetDropShadowEnabled default False;
     property DropShadowColor: TColor read GetDropShadowColor write SetDropShadowColor default clBlack;
     property DropShadowOffset: TPoint read GetDropShadowOffset write SetDropShadowOffset;
-    property DropShadowBlurRadius: Integer read GetDropShadowBlurRadius write SetDropShadowBlurRadius default 3;
+    property DropShadowBlurRadius: Integer read GetDropShadowBlurRadius write SetDropShadowBlurRadius default 3; *)
     property Opacity: Byte read FOpacity write SetOpacity default 255;
 
     property Align;
@@ -227,70 +196,23 @@ begin
   Invalidate;
 end;
 
-function TANDMR_CPanel.GetColor: TColor; begin Result := FBorderSettings.BackgroundColor; end;
-procedure TANDMR_CPanel.SetColor(const Value: TColor); begin FBorderSettings.BackgroundColor := Value; end;
-
-function TANDMR_CPanel.GetBorderColor: TColor; begin Result := FBorderSettings.Color; end;
-procedure TANDMR_CPanel.SetBorderColor(const Value: TColor); begin FBorderSettings.Color := Value; end;
-
-function TANDMR_CPanel.GetBorderThickness: Integer; begin Result := FBorderSettings.Thickness; end;
-procedure TANDMR_CPanel.SetBorderThickness(const Value: Integer); begin FBorderSettings.Thickness := Max(0,Value); end;
-
-function TANDMR_CPanel.GetBorderStyle: TPenStyle; begin Result := FBorderSettings.Style; end;
-procedure TANDMR_CPanel.SetBorderStyle(const Value: TPenStyle); begin FBorderSettings.Style := Value; end;
-
-function TANDMR_CPanel.GetCornerRadius: Integer; begin Result := FBorderSettings.CornerRadius; end;
-procedure TANDMR_CPanel.SetCornerRadius(const Value: Integer);
+procedure TANDMR_CPanel.SetBorderSettings(const Value: TBorderSettings);
 begin
-  if FBorderSettings.CornerRadius <> Max(0,Value) then
-  begin
-    FBorderSettings.CornerRadius := Max(0,Value);
-  end;
+  FBorderSettings.Assign(Value);
+  SettingsChanged(Self);
 end;
 
-function TANDMR_CPanel.GetRoundCornerType: TRoundCornerType; begin Result := FBorderSettings.RoundCornerType; end;
-procedure TANDMR_CPanel.SetRoundCornerType(const Value: TRoundCornerType);
+procedure TANDMR_CPanel.SetCaptionSettings(const Value: TCaptionSettings);
 begin
-  if FBorderSettings.RoundCornerType <> Value then
-  begin
-    FBorderSettings.RoundCornerType := Value;
-  end;
+  FCaptionSettings.Assign(Value);
+  SettingsChanged(Self);
 end;
 
-function TANDMR_CPanel.GetCaption: string; begin Result := FCaptionSettings.Text; end;
-procedure TANDMR_CPanel.SetCaption(const Value: string); begin FCaptionSettings.Text := Value; end;
-
-function TANDMR_CPanel.GetFont: TFont;
+procedure TANDMR_CPanel.SetDropShadowSettings(const Value: TDropShadowSettings);
 begin
-  Result := FCaptionSettings.Font;
+  FDropShadowSettings.Assign(Value);
+  SettingsChanged(Self);
 end;
-
-procedure TANDMR_CPanel.SetFont(Value: TFont);
-begin
-  // The published Font property should directly control the caption's font.
-  // FCaptionSettings.Font.Assign will trigger FCaptionSettings.Font.OnChange,
-  // which in turn calls FCaptionSettings.Changed, which calls Self.SettingsChanged.
-  FCaptionSettings.Font.Assign(Value);
-  // The Invalidate call here is therefore redundant if FCaptionSettings.OnChange works.
-  // However, keeping it for safety or if direct sub-property changes of Font
-  // (e.g., Font.Name := 'Arial') are made elsewhere and don't trigger through Assign.
-  // For now, let's assume FCaptionSettings.OnChange is sufficient.
-  // If Self.Invalidate is still needed, it can be added back, but
-  // TCaptionSettings.FontChanged calls Changed, which calls FOnChange, which is Self.SettingsChanged.
-  // Self.SettingsChanged calls Invalidate. So it should be fine.
-end;
-
-function TANDMR_CPanel.GetDropShadowEnabled: Boolean; begin Result := FDropShadowSettings.Enabled; end;
-procedure TANDMR_CPanel.SetDropShadowEnabled(const Value: Boolean); begin FDropShadowSettings.Enabled := Value; end;
-
-function TANDMR_CPanel.GetDropShadowColor: TColor; begin Result := FDropShadowSettings.Color; end;
-procedure TANDMR_CPanel.SetDropShadowColor(const Value: TColor); begin FDropShadowSettings.Color := Value; end;
-
-function TANDMR_CPanel.GetDropShadowOffset: TPoint; begin Result := FDropShadowSettings.Offset; end;
-procedure TANDMR_CPanel.SetDropShadowOffset(const Value: TPoint); begin FDropShadowSettings.Offset := Value; end;
-
-function TANDMR_CPanel.GetDropShadowBlurRadius: Integer; begin Result := FDropShadowSettings.BlurRadius; end;
-procedure TANDMR_CPanel.SetDropShadowBlurRadius(const Value: Integer); begin FDropShadowSettings.BlurRadius := Max(0,Value); end;
 
 procedure TANDMR_CPanel.SetOpacity(const Value: Byte);
 begin
@@ -310,24 +232,6 @@ begin
     Invalidate;
   end;
 end;
-
-function TANDMR_CPanel.GetCaptionAlignment: System.Classes.TAlignment; begin Result := FCaptionSettings.Alignment; end;
-procedure TANDMR_CPanel.SetCaptionAlignment(const Value: System.Classes.TAlignment); begin FCaptionSettings.Alignment := Value; end;
-
-function TANDMR_CPanel.GetCaptionVerticalAlignment: TCaptionVerticalAlignment; begin Result := FCaptionSettings.VerticalAlignment; end;
-procedure TANDMR_CPanel.SetCaptionVerticalAlignment(const Value: TCaptionVerticalAlignment); begin FCaptionSettings.VerticalAlignment := Value; end;
-
-function TANDMR_CPanel.GetCaptionWordWrap: Boolean; begin Result := FCaptionSettings.WordWrap; end;
-procedure TANDMR_CPanel.SetCaptionWordWrap(const Value: Boolean); begin FCaptionSettings.WordWrap := Value; end;
-
-function TANDMR_CPanel.GetCaptionOffsetX: Integer; begin Result := FCaptionSettings.Offset.X; end;
-procedure TANDMR_CPanel.SetCaptionOffsetX(const Value: Integer); begin FCaptionSettings.Offset := Point(Value, FCaptionSettings.Offset.Y); end;
-
-function TANDMR_CPanel.GetCaptionOffsetY: Integer; begin Result := FCaptionSettings.Offset.Y; end;
-procedure TANDMR_CPanel.SetCaptionOffsetY(const Value: Integer); begin FCaptionSettings.Offset := Point(FCaptionSettings.Offset.X, Value); end;
-
-function TANDMR_CPanel.GetDisabledFontColor: TColor; begin Result := FCaptionSettings.DisabledColor; end;
-procedure TANDMR_CPanel.SetDisabledFontColor(const Value: TColor); begin FCaptionSettings.DisabledColor := Value; end;
 
 procedure TANDMR_CPanel.SetTransparentChildren(const Value: Boolean);
 begin


### PR DESCRIPTION
Updated ANDMR_CButton, ANDMR_CCheckBox, ANDMR_CEdit, ANDMR_CMemo, and ANDMR_CPanel to replace local properties with direct usage of classes from ANDMR_ComponentUtils.

Key changes include:
- Border, Focus, Separator, Image, Caption, Hover, and DropShadow settings are now managed by their respective settings objects (e.g., TBorderSettings, TFocusSettings).
- Published interfaces of the components have been updated to expose these settings objects directly, removing redundant individual proxy properties. For example, instead of `MyButton.CornerRadius`, you should now use `MyButton.BorderSettings.CornerRadius`.
- Internal logic, including Paint methods and layout calculations, has been updated to source values from these settings objects.
- Event handling for `OnChange` within settings objects has been standardized to trigger component invalidation and updates.
- In ANDMR_CButton, tag-related properties were consolidated into a single `AndmrTag: TANDMR_Tag` property.

This refactoring improves consistency, organization, and extensibility of component properties.