### PR TITLE
Add predefined styles to TANDMR_CEdit

### DIFF
--- a/Source/ANDMR_ComponentUtils.pas
+++ b/Source/ANDMR_ComponentUtils.pas
@@ -38,6 +38,13 @@ type
     pmtDateDMY
   );
 
+  TCEditPredefinedStyle = (
+    cepsNormal,
+    cepsError,
+    cepsWarning,
+    cepsSuccess
+  );
+
   TTagType = (ttDefault, ttString, ttExtended, ttObject);
 
   TANDMR_Tag = class(TPersistent)


### PR DESCRIPTION
This commit introduces a new `PredefinedStyle` property to the `TANDMR_CEdit` component. This allows developers to easily apply common visual styles such as 'Error', 'Warning', and 'Success'.

Key changes:
- Added `TCEditPredefinedStyle` enumeration (`cepsNormal`, `cepsError`, `cepsWarning`, `cepsSuccess`) in `ANDMR_ComponentUtils.pas`.
- Added `PredefinedStyle` property to `TANDMR_CEdit` in `ANDMR_CEdit.pas`.
- Implemented the `SetPredefinedStyle` method to adjust `FBorderSettings.Color`, `FFocusSettings.BorderColor`, and `Font.Color` based on the selected style.
- Initialized the `PredefinedStyle` to `cepsNormal` in the constructor.
- The `Paint` method will automatically use these updated colors.

I recommend you manually check the visual appearance of the different predefined styles.