### PR TITLE
Fix: Adjust CMemo content for rounded borders

### DIFF
--- a/Source/ANDMR_CMemo.pas
+++ b/Source/ANDMR_CMemo.pas
@@ -676,6 +676,35 @@ begin
   MemoRect.Right  := LTxtRect.Right - FTextMargins.Right;
   MemoRect.Bottom := LTxtRect.Bottom - FTextMargins.Bottom;
 
+  if (Self.FBorderSettings.CornerRadius > 0) and (Self.FBorderSettings.RoundCornerType <> TRoundCornerType.rctNone) then
+  begin
+    var CornerPadding: Integer;
+    CornerPadding := Round(Self.FBorderSettings.CornerRadius * 0.5);
+
+    var IsTopLeftRounded, IsTopRightRounded, IsBottomLeftRounded, IsBottomRightRounded: Boolean;
+
+    IsTopLeftRounded := Self.FBorderSettings.RoundCornerType in
+      [TRoundCornerType.rctAll, TRoundCornerType.rctTopLeft, TRoundCornerType.rctTop, TRoundCornerType.rctLeft, TRoundCornerType.rctTopLeftBottomRight];
+    IsTopRightRounded := Self.FBorderSettings.RoundCornerType in
+      [TRoundCornerType.rctAll, TRoundCornerType.rctTopRight, TRoundCornerType.rctTop, TRoundCornerType.rctRight, TRoundCornerType.rctTopRightBottomLeft];
+    IsBottomLeftRounded := Self.FBorderSettings.RoundCornerType in
+      [TRoundCornerType.rctAll, TRoundCornerType.rctBottomLeft, TRoundCornerType.rctBottom, TRoundCornerType.rctLeft, TRoundCornerType.rctTopRightBottomLeft];
+    IsBottomRightRounded := Self.FBorderSettings.RoundCornerType in
+      [TRoundCornerType.rctAll, TRoundCornerType.rctBottomRight, TRoundCornerType.rctBottom, TRoundCornerType.rctRight, TRoundCornerType.rctTopLeftBottomRight];
+
+    if IsTopLeftRounded or IsBottomLeftRounded then
+      MemoRect.Left := MemoRect.Left + CornerPadding;
+
+    if IsTopRightRounded or IsBottomRightRounded then
+      MemoRect.Right := MemoRect.Right - CornerPadding;
+
+    if IsTopLeftRounded or IsTopRightRounded then
+      MemoRect.Top := MemoRect.Top + CornerPadding;
+
+    if IsBottomLeftRounded or IsBottomRightRounded then
+      MemoRect.Bottom := MemoRect.Bottom - CornerPadding;
+  end;
+
   if MemoRect.Right < MemoRect.Left then MemoRect.Right := MemoRect.Left;
   if MemoRect.Bottom < MemoRect.Top then MemoRect.Bottom := MemoRect.Top;
 


### PR DESCRIPTION
I've revised the calculation within the CMemo component to ensure that the internal text content area correctly adjusts when you apply rounded borders.

The `UpdateInternalMemoBounds` procedure in `ANDMR_CMemo.pas` was modified to:
- Check if rounded corners are active (`FBorderSettings.CornerRadius > 0` and `RoundCornerType <> rctNone`).
- Calculate an additional padding amount proportional to `CornerRadius` (specifically, `CornerRadius * 0.5`).
- Apply this padding to the internal memo's bounding rectangle (`MemoRect`) on the sides adjacent to any rounded corners. This prevents the text from rendering over the curved border areas.

This change ensures that the text content respects the visual boundaries imposed by rounded corners, improving the component's appearance and usability.