### PR TITLE
Refactor: Allow user-defined or automatic image sizing

### DIFF
--- a/Source/ANDMR_CButton.pas
+++ b/Source/ANDMR_CButton.pas
@@ -1630,46 +1630,144 @@ begin
       if (FImageSettings.Picture.Graphic <> nil) and not FImageSettings.Picture.Graphic.Empty then // Use FImageSettings.Picture
       begin
         LImgW := FImageSettings.Picture.Width; LImgH := FImageSettings.Picture.Height; // Use FImageSettings.Picture
-        case FImageSettings.DrawMode of // Use FImageSettings.DrawMode
-        idmProportional: // Changed from ismProportional
+
+        // Calculate AvailableImageWidth and AvailableImageHeight
+        AvailableWidth := Max(0, LImageClipRect.Width - FImageSettings.Margins.Left - FImageSettings.Margins.Right);
+        AvailableHeight := Max(0, LImageClipRect.Height - FImageSettings.Margins.Top - FImageSettings.Margins.Bottom);
+
+        if FImageSettings.AutoSize then
         begin
-          if (LImgW = 0) or (LImgH = 0) then begin LDrawW := 0; LDrawH := 0; end
-          else
-          begin
-            AvailableWidth  := Max(0, LImageClipRect.Width - FImageSettings.Margins.Left - FImageSettings.Margins.Right); // Use FImageSettings.Margins
-            AvailableHeight := Max(0, LImageClipRect.Height - FImageSettings.Margins.Top - FImageSettings.Margins.Bottom); // Use FImageSettings.Margins
-            if FImagePosition in [ipLeft, ipRight] then
+          case FImageSettings.DrawMode of
+            idmStretch:
             begin
+              LDrawW := AvailableWidth;
               LDrawH := AvailableHeight;
-              if LImgH <> 0 then LDrawW := Round(LImgW / LImgH * LDrawH) else LDrawW := 0;
+            end;
+            idmProportional:
+            begin
+              if (LImgW = 0) or (LImgH = 0) then
+              begin
+                LDrawW := 0; LDrawH := 0;
+              end
+              else
+              begin
+                LScaleFactor := Min(AvailableWidth / LImgW, AvailableHeight / LImgH);
+                LDrawW := Round(LImgW * LScaleFactor);
+                LDrawH := Round(LImgH * LScaleFactor);
+              end;
+            end;
+            idmNormal:
+            begin
+              LDrawW := LImgW;
+              LDrawH := LImgH;
+              // Clamp to available space if normal size exceeds it
               if LDrawW > AvailableWidth then
               begin
                 LDrawW := AvailableWidth;
-                if LImgW <> 0 then LDrawH := Round(LImgH / LImgW * LDrawW) else LDrawH := 0;
+                // Optionally, scale LDrawH proportionally, or just clamp it too
+                if LImgW > 0 then LDrawH := Round(LImgH * (AvailableWidth / LImgW));
               end;
-            end
-            else
-            begin
-              LDrawW := AvailableWidth;
-              if LImgW <> 0 then LDrawH := Round(LImgH / LImgW * LDrawW) else LDrawH := 0;
               if LDrawH > AvailableHeight then
               begin
                 LDrawH := AvailableHeight;
-                if LImgH <> 0 then LDrawW := Round(LImgW / LImgH * LDrawH) else LDrawW := 0;
+                // Optionally, scale LDrawW proportionally if LDrawH was clamped
+                if LImgH > 0 then LDrawW := Round(LImgW * (AvailableHeight / LImgH));
+                 // Re-clamp LDrawW if it now exceeds AvailableWidth due to LDrawH scaling
+                if LDrawW > AvailableWidth then LDrawW := AvailableWidth;
+              end;
+            end;
+          else // Default to proportional if DrawMode is somehow not one of the above
+            begin
+              if (LImgW = 0) or (LImgH = 0) then
+              begin LDrawW := 0; LDrawH := 0; end
+              else
+              begin
+                LScaleFactor := Min(AvailableWidth / LImgW, AvailableHeight / LImgH);
+                LDrawW := Round(LImgW * LScaleFactor);
+                LDrawH := Round(LImgH * LScaleFactor);
               end;
             end;
           end;
-        end;
-        idmStretch: // Changed from ismFlat
+        end
+        else // AutoSize is False, use TargetWidth/TargetHeight
         begin
-          LDrawW := Max(0, LImageClipRect.Width - FImageSettings.Margins.Left - FImageSettings.Margins.Right); // Use FImageSettings.Margins
-          LDrawH := Max(0, LImageClipRect.Height - FImageSettings.Margins.Top - FImageSettings.Margins.Bottom); // Use FImageSettings.Margins
+          LDrawW := FImageSettings.TargetWidth;
+          LDrawH := FImageSettings.TargetHeight;
+
+          if (LDrawW = 0) and (LDrawH = 0) then
+          begin
+            if FImageSettings.DrawMode = idmStretch then
+            begin
+              LDrawW := AvailableWidth;
+              LDrawH := AvailableHeight;
+            end
+            else // idmProportional or idmNormal
+            begin
+              LDrawW := LImgW;
+              LDrawH := LImgH;
+            end;
+          end
+          else if (LDrawW = 0) and (LDrawH > 0) then // Width is 0, Height is specified
+          begin
+            if LImgH > 0 then LDrawW := Round(LImgW / LImgH * LDrawH)
+            else LDrawW := LImgW; // Fallback if original height is 0
+          end
+          else if (LDrawW > 0) and (LDrawH = 0) then // Height is 0, Width is specified
+          begin
+            if LImgW > 0 then LDrawH := Round(LImgH / LImgW * LDrawW)
+            else LDrawH := LImgH; // Fallback if original width is 0
+          end;
+
+          // Apply DrawMode to user-defined size (LDrawW, LDrawH from TargetWidth/Height)
+          if FImageSettings.DrawMode = idmProportional then
+          begin
+            if (LDrawW > 0) and (LDrawH > 0) and (LImgW > 0) and (LImgH > 0) then
+            begin
+              LScaleFactor := Min(LDrawW / LImgW, LDrawH / LImgH);
+              LDrawW := Round(LImgW * LScaleFactor);
+              LDrawH := Round(LImgH * LScaleFactor);
+            end;
+            // If LImgW or LImgH is 0, or LDrawW/LDrawH are 0, proportional scaling isn't well-defined.
+            // The previous steps for handling 0 target dimensions should cover this.
+          end
+          else if FImageSettings.DrawMode = idmNormal then
+          begin
+            // For idmNormal with specific TargetWidth/Height, it's a bit ambiguous.
+            // Option 1: Use TargetWidth/Height as absolute, ignoring original image size (current LDrawW/LDrawH).
+            // Option 2: Use original image size (LImgW, LImgH) and ignore TargetWidth/Height if DrawMode is Normal.
+            // The current logic sets LDrawW/LDrawH from TargetWidth/Height, so we'll assume Option 1.
+            // No change needed here for idmNormal, LDrawW/LDrawH are already set.
+          end;
+          // For idmStretch, LDrawW and LDrawH are already set from TargetWidth/Height (or derived if one was 0).
+          // The image will be stretched to these dimensions.
+
+          // Clamping to available space for AutoSize = False
+          if (LDrawW > AvailableWidth) or (LDrawH > AvailableHeight) then
+          begin
+            if (LDrawW > 0) and (LDrawH > 0) then // Only scale if both are positive
+            begin
+              LScaleFactor := Min(AvailableWidth / LDrawW, AvailableHeight / LDrawH);
+              LDrawW := Round(LDrawW * LScaleFactor);
+              LDrawH := Round(LDrawH * LScaleFactor);
+            end
+            else // If one dimension is zero or negative, just hard clamp
+            begin
+               LDrawW := Min(LDrawW, AvailableWidth);
+               LDrawH := Min(LDrawH, AvailableHeight);
+            end;
+          end;
         end;
-      else LDrawW := LImgW; LDrawH := LImgH; // Default case if FImageSettings.DrawMode is neither
+
+        // Ensure LDrawW and LDrawH are not negative
+        LDrawW := Max(0, LDrawW);
+        LDrawH := Max(0, LDrawH);
       end;
 
+      // Fallback if image dimensions are still zero after calculations (e.g. empty image, zero available space)
+      // This was the original fallback, ensure it's still relevant
       if (LImgW > 0) and (LDrawW <=0) then LDrawW := Min(LImgW, Max(0, LImageClipRect.Width div 3));
       if (LImgH > 0) and (LDrawH <=0) then LDrawH := Min(LImgH, Max(0, LImageClipRect.Height div 3));
+
 
       case FImagePosition of
         ipLeft:

--- a/Source/ANDMR_CEdit.pas
+++ b/Source/ANDMR_CEdit.pas
@@ -546,36 +546,31 @@ begin
     OriginalImgW := FImageSettings.Picture.Graphic.Width;
     OriginalImgH := FImageSettings.Picture.Graphic.Height;
 
-    if (OriginalImgW > 0) and (OriginalImgH > 0) then
-    begin
-      availWForImg := WorkArea.Width - FImageSettings.Margins.Left - FImageSettings.Margins.Right;
-      availHForImg := WorkArea.Height - FImageSettings.Margins.Top - FImageSettings.Margins.Bottom;
-      availWForImg := Max(0, availWForImg);
-      availHForImg := Max(0, availHForImg);
+    availWForImg := Max(0, WorkArea.Width - FImageSettings.Margins.Left - FImageSettings.Margins.Right);
+    availHForImg := Max(0, WorkArea.Height - FImageSettings.Margins.Top - FImageSettings.Margins.Bottom);
 
-      if (availWForImg > 0) and (availHForImg > 0) then
+    if FImageSettings.AutoSize then
+    begin
+      // AutoSize True: Size image based on available space and DrawMode
+      if (OriginalImgW > 0) and (OriginalImgH > 0) and (availWForImg > 0) and (availHForImg > 0) then
       begin
         case FImageSettings.DrawMode of
           idmProportional:
           begin
             rImageRatio := OriginalImgW / OriginalImgH;
             rAvailBoxRatio := availWForImg / availHForImg;
-            if rAvailBoxRatio > rImageRatio then
+            if rAvailBoxRatio > rImageRatio then // Fit to height
             begin
               ImgH := availHForImg;
               tempW := availHForImg * rImageRatio;
               ImgW := Round(tempW);
               if (ImgW = 0) and (tempW > 0) then ImgW := 1;
             end
-            else
+            else // Fit to width
             begin
               ImgW := availWForImg;
-              if rImageRatio > 0 then
-              begin
-                tempH := availWForImg / rImageRatio;
-                ImgH := Round(tempH);
-                if (ImgH = 0) and (tempH > 0) then ImgH := 1;
-              end else ImgH := 0;
+              if rImageRatio > 0 then begin tempH := availWForImg / rImageRatio; ImgH := Round(tempH); if (ImgH = 0) and (tempH > 0) then ImgH := 1; end
+              else ImgH := 0;
             end;
           end;
           idmStretch:
@@ -587,16 +582,89 @@ begin
           begin
             ImgW := OriginalImgW;
             ImgH := OriginalImgH;
+            // Clamp to available space if normal size exceeds it
+            if ImgW > availWForImg then ImgW := availWForImg;
+            if ImgH > availHForImg then ImgH := availHForImg;
           end;
-        else // Default to proportional if unknown
+        else // Default to proportional
+          rImageRatio := OriginalImgW / OriginalImgH;
+          rAvailBoxRatio := availWForImg / availHForImg;
+          if rAvailBoxRatio > rImageRatio then begin ImgH := availHForImg; tempW := availHForImg * rImageRatio; ImgW := Round(tempW); if (ImgW = 0) and (tempW > 0) then ImgW := 1; end
+          else begin ImgW := availWForImg; if rImageRatio > 0 then begin tempH := availWForImg / rImageRatio; ImgH := Round(tempH); if (ImgH = 0) and (tempH > 0) then ImgH := 1; end else ImgH := 0; end;
+        end;
+      end
+      else // Original image has no size or no available space
+      begin
+        ImgW := 0; ImgH := 0;
+      end;
+    end
+    else // AutoSize = False: Use TargetWidth/TargetHeight
+    begin
+      ImgW := FImageSettings.TargetWidth;
+      ImgH := FImageSettings.TargetHeight;
+
+      if (ImgW = 0) and (ImgH = 0) then
+      begin
+        if FImageSettings.DrawMode = idmStretch then
+        begin
+          ImgW := availWForImg;
+          ImgH := availHForImg;
+        end
+        else // idmProportional or idmNormal for 0,0 Target uses original image size
+        begin
+          ImgW := OriginalImgW;
+          ImgH := OriginalImgH;
+        end;
+      end
+      else if (ImgW = 0) and (ImgH > 0) then // Width is 0, Height is specified
+      begin
+        if OriginalImgH > 0 then ImgW := Round(OriginalImgW / OriginalImgH * ImgH)
+        else ImgW := OriginalImgW; // Fallback
+      end
+      else if (ImgW > 0) and (ImgH = 0) then // Height is 0, Width is specified
+      begin
+        if OriginalImgW > 0 then ImgH := Round(OriginalImgH / OriginalImgW * ImgW)
+        else ImgH := OriginalImgH; // Fallback
+      end;
+
+      // Apply DrawMode idmProportional to the TargetWidth/Height derived ImgW/ImgH
+      if FImageSettings.DrawMode = idmProportional then
+      begin
+        if (ImgW > 0) and (ImgH > 0) and (OriginalImgW > 0) and (OriginalImgH > 0) then
+        begin
+            var TargetRatio: Double := ImgW / ImgH;
             rImageRatio := OriginalImgW / OriginalImgH;
-            rAvailBoxRatio := availWForImg / availHForImg;
-            if rAvailBoxRatio > rImageRatio then begin ImgH := availHForImg; tempW := availHForImg * rImageRatio; ImgW := Round(tempW); if (ImgW = 0) and (tempW > 0) then ImgW := 1; end
-            else begin ImgW := availWForImg; if rImageRatio > 0 then begin tempH := availWForImg / rImageRatio; ImgH := Round(tempH); if (ImgH = 0) and (tempH > 0) then ImgH := 1; end else ImgH := 0; end;
+            if TargetRatio > rImageRatio then // Target rect is wider than image ratio, fit to height
+            begin
+                ImgW := Round(ImgH * rImageRatio);
+            end
+            else // Target rect is taller or same ratio, fit to width
+            begin
+                ImgH := Round(ImgW / rImageRatio);
+            end;
+        end;
+      end;
+      // For idmStretch or idmNormal, ImgW/ImgH are already set from TargetWidth/Height.
+
+      // Clamping to available space for AutoSize = False
+      if (ImgW > availWForImg) or (ImgH > availHForImg) then
+      begin
+        if (ImgW > 0) and (ImgH > 0) then // Only scale if both are positive
+        begin
+          var ScaleFactorW: Double; if ImgW > 0 then ScaleFactorW := availWForImg / ImgW else ScaleFactorW := 1.0;
+          var ScaleFactorH: Double; if ImgH > 0 then ScaleFactorH := availHForImg / ImgH else ScaleFactorH := 1.0;
+          var LScaleFactor := Min(ScaleFactorW, ScaleFactorH);
+          ImgW := Round(ImgW * LScaleFactor);
+          ImgH := Round(ImgH * LScaleFactor);
+        end
+        else // If one dimension is zero or negative, just hard clamp
+        begin
+           ImgW := Min(ImgW, availWForImg);
+           ImgH := Min(ImgH, availHForImg);
         end;
       end;
     end;
-  end;
+  end; // End of: if FImageSettings.Visible and Assigned(FImageSettings.Picture.Graphic) and not FImageSettings.Picture.Graphic.Empty then
 
   ImgW := Max(0, ImgW);
   ImgH := Max(0, ImgH);

--- a/Source/ANDMR_ComponentUtils.pas
+++ b/Source/ANDMR_ComponentUtils.pas
@@ -239,7 +239,10 @@ type
     FPlacement: TImagePlacement;
     FTargetWidth: Integer;      // Added
     FTargetHeight: Integer;     // Added
+    FAutoSize: Boolean;
 
+    function GetAutoSize: Boolean;
+    procedure SetAutoSize(const Value: Boolean);
     procedure SetPicture(const Value: TPicture);
     procedure SetVisible(const Value: Boolean);
     procedure SetDrawMode(const Value: TImageDrawMode);
@@ -267,6 +270,7 @@ type
     property Placement: TImagePlacement read FPlacement write SetPlacement default iplInsideBounds;
     property TargetWidth: Integer read FTargetWidth write SetTargetWidth default 0; // Added
     property TargetHeight: Integer read FTargetHeight write SetTargetHeight default 0; // Added
+    property AutoSize: Boolean read FAutoSize write SetAutoSize default True;
     property OnChange: TNotifyEvent read FOnChange write FOnChange;
   end;
 
@@ -1400,6 +1404,7 @@ begin
   FPlacement := iplInsideBounds;
   FTargetWidth := 0;  // Added initialization
   FTargetHeight := 0; // Added initialization
+  FAutoSize := True;
 end;
 
 destructor TImageSettings.Destroy;
@@ -1436,6 +1441,7 @@ begin
     SetPlacement(LSource.Placement);
     SetTargetWidth(LSource.TargetWidth);     // Added assignment
     SetTargetHeight(LSource.TargetHeight);   // Added assignment
+    SetAutoSize(LSource.AutoSize); // Added assignment
     // DoChange is called by setters.
   end
   else
@@ -1472,6 +1478,20 @@ begin
   if FTargetHeight <> Value then
   begin
     FTargetHeight := Max(0, Value); // Ensure non-negative
+    DoChange;
+  end;
+end;
+
+function TImageSettings.GetAutoSize: Boolean;
+begin
+  Result := FAutoSize;
+end;
+
+procedure TImageSettings.SetAutoSize(const Value: Boolean);
+begin
+  if FAutoSize <> Value then
+  begin
+    FAutoSize := Value;
     DoChange;
   end;
 end;


### PR DESCRIPTION
This change refactors image handling in visual components (`TANDMR_CButton`, `TANDMR_CCheckBox`, `TANDMR_CEdit`) to provide more flexible image sizing.

Key changes:
- Added an `AutoSize` boolean property to `TImageSettings` (in `ANDMR_ComponentUtils.pas`).
  - If `True` (default), the image size is determined automatically based on the available space within the component and the `DrawMode` (proportional, stretch, normal).
  - If `False`, the image size is determined by `TargetWidth` and `TargetHeight` properties in `TImageSettings`.
    - If `TargetWidth` or `TargetHeight` is 0, the missing dimension is calculated proportionally or based on the original image size, respecting the `DrawMode`.
    - User-defined sizes are clamped to the available component space to prevent overflow.

- Modified the `Paint` (or `CalculateLayout` for `TANDMR_CEdit`) methods in `ANDMR_CButton.pas`, `ANDMR_CCheckBox.pas`, and `ANDMR_CEdit.pas` to implement this new sizing logic.

This allows you to either have images scale automatically with the component or specify fixed dimensions for the image display area.