### PR TITLE
Fix: Add Transparent property to ANDMR_CButtonGroup

### DIFF
--- a/ANDMR_COMPONENTES.dpk
+++ b/ANDMR_COMPONENTES.dpk
@@ -39,6 +39,7 @@ contains
   ANDMR_ComponentUtils in 'Source\ANDMR_ComponentUtils.pas',
   ANDMR_CPanel in 'Source\ANDMR_CPanel.pas',
   ANDMR_CCheckBox in 'Source\ANDMR_CCheckBox.pas',
-  ANDMR_CRadioGroup in 'Source\ANDMR_CRadioGroup.pas';
+  ANDMR_CRadioGroup in 'Source\ANDMR_CRadioGroup.pas',
+  ANDMR_CButtonGroup in 'Source\ANDMR_CButtonGroup.pas';
 
 end.

--- a/ButtonGroupTestForm.dfm
+++ b/ButtonGroupTestForm.dfm
@@ -14,98 +14,103 @@ object FormButtonGroupTest: TFormButtonGroupTest
   OnCreate = FormCreate
   PixelsPerInch = 96
   TextHeight = 13
-  object bgHorizontal: TANDMR_CButtonGroup
+  object bgHorizontal: TANDMR_CButtonGroup // Ensure this is the new component
     Left = 24
     Top = 24
-    Width = 300
-    Height = 75
-    ActiveButtonColor = clHighlight
-    InactiveButtonColor = clBtnFace
-    ActiveButtonFontColor = clHighlightText
-    InactiveButtonFontColor = clWindowText
-    Orientation = bgoHorizontal
-    ButtonSpacing = 4
-    ActiveButtonIndex = -1
+    Width = 550
+    Height = 60
     TabOrder = 0
-    object btnH1: TANDMR_CButton
-      Left = 0
-      Top = 0
-      Width = 97
-      Height = 75
-      Caption = 'Button 1'
-      TabOrder = 0
-      ActiveColor = clBtnFace
-      TitleFont.Color = clWindowText
-      OnClick = nil // Will be assigned by ButtonGroup
-    end
-    object btnH2: TANDMR_CButton
-      Left = 101
-      Top = 0
-      Width = 97
-      Height = 75
-      Caption = 'Button 2'
-      TabOrder = 1
-      ActiveColor = clBtnFace
-      TitleFont.Color = clWindowText
-      OnClick = nil // Will be assigned by ButtonGroup
-    end
-    object btnH3: TANDMR_CButton
-      Left = 202
-      Top = 0
-      Width = 97
-      Height = 75
-      Caption = 'Button 3'
-      TabOrder = 2
-      ActiveColor = clBtnFace
-      TitleFont.Color = clWindowText
-      OnClick = nil // Will be assigned by ButtonGroup
-    end
+    Orientation = bgoHorizontal
+    ButtonSpacing = 5
+    ActiveButtonColor = clBlue // Example initial active color
+    InactiveButtonColor = clWhite
+    ActiveButtonFontColor = clWhite
+    InactiveButtonFontColor = clBlack
+    BorderSettings.CornerRadius = 8
+    BorderSettings.Color = clGray
+    BorderSettings.Thickness = 1
+    SeparatorSettings.Visible = True
+    SeparatorSettings.Color = clMedGray
+    SeparatorSettings.Thickness = 1
+    SeparatorSettings.Padding = 2
   end
-  object bgVertical: TANDMR_CButtonGroup
+  object bgVertical: TANDMR_CButtonGroup // Ensure this is the new component
     Left = 24
-    Top = 120
+    Top = 100
     Width = 150
-    Height = 250
-    ActiveButtonColor = clHighlight
-    InactiveButtonColor = clBtnFace
-    ActiveButtonFontColor = clHighlightText
-    InactiveButtonFontColor = clWindowText
-    Orientation = bgoVertical
-    ButtonSpacing = 4
-    ActiveButtonIndex = -1
+    Height = 300
     TabOrder = 1
-    object btnV1: TANDMR_CButton
-      Left = 0
-      Top = 0
-      Width = 150
-      Height = 80
-      Caption = 'Option A'
-      TabOrder = 0
-      ActiveColor = clBtnFace
-      TitleFont.Color = clWindowText
-      OnClick = nil // Will be assigned by ButtonGroup
-    end
-    object btnV2: TANDMR_CButton
-      Left = 0
-      Top = 84
-      Width = 150
-      Height = 80
-      Caption = 'Option B'
-      TabOrder = 1
-      ActiveColor = clBtnFace
-      TitleFont.Color = clWindowText
-      OnClick = nil // Will be assigned by ButtonGroup
-    end
-    object btnV3: TANDMR_CButton
-      Left = 0
-      Top = 168
-      Width = 150
-      Height = 80
-      Caption = 'Option C'
-      TabOrder = 2
-      ActiveColor = clBtnFace
-      TitleFont.Color = clWindowText
-      OnClick = nil // Will be assigned by ButtonGroup
-    end
+    Orientation = bgoVertical
+    ButtonSpacing = 3
+    ActiveButtonColor = clGreen
+    InactiveButtonColor = clSilver
+    ActiveButtonFontColor = clWhite
+    InactiveButtonFontColor = clBlack
+    BorderSettings.CornerRadius = 6
+    BorderSettings.Color = clGray
+    BorderSettings.Thickness = 1
+    SeparatorSettings.Visible = True
+    SeparatorSettings.Thickness = 2
+    SeparatorSettings.Padding = 3
+  end
+  // Add VCL Buttons for testing
+  object btnAddH: TButton
+    Left = 24
+    Top = 400
+    Width = 100
+    Height = 25
+    Caption = 'Add to Horz'
+    TabOrder = 2
+    OnClick = btnAddHClick
+  end
+  object btnAddV: TButton
+    Left = 136
+    Top = 400
+    Width = 100
+    Height = 25
+    Caption = 'Add to Vert'
+    TabOrder = 3
+    OnClick = btnAddVClick
+  end
+  object btnClearH: TButton
+    Left = 248
+    Top = 400
+    Width = 100
+    Height = 25
+    Caption = 'Clear Horz'
+    TabOrder = 4
+    OnClick = btnClearHClick
+  end
+  object btnClearV: TButton
+    Left = 360
+    Top = 400
+    Width = 100
+    Height = 25
+    Caption = 'Clear Vert'
+    TabOrder = 5
+    OnClick = btnClearVClick
+  end
+  object chkHorzOrientation: TCheckBox
+    Left = 470
+    Top = 400
+    Width = 120
+    Height = 17
+    Caption = 'Vertical Horz Grp'
+    TabOrder = 6
+    OnClick = chkHorzOrientationClick
+  end
+  object lblSelectedH: TLabel
+    Left = 24
+    Top = 88
+    Width = 300
+    Height = 13
+    Caption = 'Selected H:'
+  end
+  object lblSelectedV: TLabel
+    Left = 180
+    Top = 88
+    Width = 300
+    Height = 13
+    Caption = 'Selected V:'
   end
 end

--- a/ButtonGroupTestForm.pas
+++ b/ButtonGroupTestForm.pas
@@ -4,22 +4,31 @@ interface
 
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls,
-  ANDMR_CButtonGroup, ANDMR_CButton;
+  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, Vcl.ExtCtrls, // Added ExtCtrls for TLabel
+  ANDMR_CButtonGroup, ANDMR_CButton, ANDMR_ComponentUtils; // Ensure ANDMR_ComponentUtils is used
 
 type
   TFormButtonGroupTest = class(TForm)
     bgHorizontal: TANDMR_CButtonGroup;
-    btnH1: TANDMR_CButton;
-    btnH2: TANDMR_CButton;
-    btnH3: TANDMR_CButton;
     bgVertical: TANDMR_CButtonGroup;
-    btnV1: TANDMR_CButton;
-    btnV2: TANDMR_CButton;
-    btnV3: TANDMR_CButton;
+    btnAddH: TButton;
+    btnAddV: TButton;
+    btnClearH: TButton;
+    btnClearV: TButton;
+    chkHorzOrientation: TCheckBox;
+    lblSelectedH: TLabel;
+    lblSelectedV: TLabel;
     procedure FormCreate(Sender: TObject);
+    procedure btnAddHClick(Sender: TObject);
+    procedure btnAddVClick(Sender: TObject);
+    procedure btnClearHClick(Sender: TObject);
+    procedure btnClearVClick(Sender: TObject);
+    procedure chkHorzOrientationClick(Sender: TObject);
+    procedure BgHorizontalClick(Sender: TObject);
+    procedure BgVerticalClick(Sender: TObject);
   private
-    { Private declarations }
+    FHCounter: Integer;
+    FVCounter: Integer;
   public
     { Public declarations }
   end;
@@ -32,11 +41,86 @@ implementation
 {$R *.dfm}
 
 procedure TFormButtonGroupTest.FormCreate(Sender: TObject);
+var
+  i: Integer;
+  NewBtn: TANDMR_CButton;
 begin
-  // Code to run on form creation, if any specific setup is needed here.
-  // For example, to test changing properties programmatically:
-  // bgHorizontal.ButtonSpacing := 10;
-  // bgVertical.ActiveButtonColor := clLime;
+  FHCounter := 0;
+  FVCounter := 0;
+
+  // Add initial buttons to Horizontal Group
+  for i := 1 to 3 do
+  begin
+    Inc(FHCounter);
+    NewBtn := bgHorizontal.AddButton('H' + IntToStr(FHCounter));
+    // Optionally, customize NewBtn further if needed for testing
+    // Example: NewBtn.ImageSettings.Picture.LoadFromFile('some_icon.png');
+  end;
+
+  // Add initial buttons to Vertical Group
+  for i := 1 to 2 do
+  begin
+    Inc(FVCounter);
+    bgVertical.AddButton('V' + IntToStr(FVCounter));
+  end;
+
+  // Assign OnClick handlers to update labels
+  bgHorizontal.OnClick := BgHorizontalClick;
+  bgVertical.OnClick := BgVerticalClick;
+
+  // Initial label update
+  BgHorizontalClick(bgHorizontal);
+  BgVerticalClick(bgVertical);
+end;
+
+procedure TFormButtonGroupTest.btnAddHClick(Sender: TObject);
+begin
+  Inc(FHCounter);
+  bgHorizontal.AddButton('H' + IntToStr(FHCounter));
+end;
+
+procedure TFormButtonGroupTest.btnAddVClick(Sender: TObject);
+begin
+  Inc(FVCounter);
+  bgVertical.AddButton('V' + IntToStr(FVCounter));
+end;
+
+procedure TFormButtonGroupTest.btnClearHClick(Sender: TObject);
+begin
+  bgHorizontal.ClearButtons;
+  FHCounter := 0;
+  BgHorizontalClick(bgHorizontal); // Update label
+end;
+
+procedure TFormButtonGroupTest.btnClearVClick(Sender: TObject);
+begin
+  bgVertical.ClearButtons;
+  FVCounter := 0;
+  BgVerticalClick(bgVertical); // Update label
+end;
+
+procedure TFormButtonGroupTest.chkHorzOrientationClick(Sender: TObject);
+begin
+  if chkHorzOrientation.Checked then
+    bgHorizontal.Orientation := bgoVertical
+  else
+    bgHorizontal.Orientation := bgoHorizontal;
+end;
+
+procedure TFormButtonGroupTest.BgHorizontalClick(Sender: TObject);
+begin
+  if Assigned(bgHorizontal.SelectedButton) then
+    lblSelectedH.Caption := 'Selected H: ' + bgHorizontal.SelectedButton.Caption
+  else
+    lblSelectedH.Caption := 'Selected H: None';
+end;
+
+procedure TFormButtonGroupTest.BgVerticalClick(Sender: TObject);
+begin
+  if Assigned(bgVertical.SelectedButton) then
+    lblSelectedV.Caption := 'Selected V: ' + bgVertical.SelectedButton.Caption
+  else
+    lblSelectedV.Caption := 'Selected V: None';
 end;
 
 end.

--- a/Source/ANDMR_CButtonGroup.pas
+++ b/Source/ANDMR_CButtonGroup.pas
@@ -1,0 +1,666 @@
+unit ANDMR_CButtonGroup;
+
+interface
+
+uses
+  System.SysUtils, System.Classes, System.Contnrs, // Added System.Contnrs
+  Vcl.Controls, Vcl.Graphics, Winapi.Windows,
+  Vcl.ExtCtrls, Winapi.Messages, Vcl.Forms, Vcl.StdCtrls, System.Types, System.UITypes,
+  System.Math, Winapi.GDIPOBJ, Winapi.GDIPAPI,
+  ANDMR_CButton, ANDMR_ComponentUtils;
+
+type
+  TANDMR_ButtonGroupOrientation = (bgoHorizontal, bgoVertical);
+
+  TANDMR_CButtonGroup = class(TCustomControl)
+  private
+    FButtons: TObjectList;
+    FOrientation: TANDMR_ButtonGroupOrientation;
+    FButtonSpacing: Integer;
+    FSelectedButton: TANDMR_CButton;
+    FBorderSettings: TBorderSettings;
+    FHoverSettings: THoverSettings;
+    FSeparatorSettings: TSeparatorSettings;
+    FAllowMultiSelect: Boolean; // Added
+    FActiveButtonColor: TColor;
+    FInactiveButtonColor: TColor;
+    FActiveButtonFontColor: TColor;
+    FInactiveButtonFontColor: TColor;
+    FTransparent: Boolean;
+
+
+    procedure SetOrientation(const Value: TANDMR_ButtonGroupOrientation);
+    procedure SetButtonSpacing(const Value: Integer);
+    procedure SetBorderSettings(const Value: TBorderSettings);
+    procedure SetHoverSettings(const Value: THoverSettings);
+    procedure SetSeparatorSettings(const Value: TSeparatorSettings);
+    procedure SetAllowMultiSelect(const Value: Boolean); // Added
+    procedure SetActiveButtonColor(const Value: TColor);
+    procedure SetInactiveButtonColor(const Value: TColor);
+    procedure SetActiveButtonFontColor(const Value: TColor);
+    procedure SetInactiveButtonFontColor(const Value: TColor);
+    procedure SetTransparent(const Value: Boolean);
+
+
+    procedure ButtonClickHandler(Sender: TObject);
+    procedure SettingsChanged(Sender: TObject);
+    procedure UpdateButtonsStyle;
+
+
+  protected
+    procedure Paint; override;
+    procedure Loaded; override;
+    procedure Notification(AComponent: TComponent; Operation: TOperation); override;
+    procedure Resize; override;
+
+  public
+    constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+
+    function AddButton(ACaption: string = ''; AImage: TPicture = nil): TANDMR_CButton;
+    procedure RemoveButton(AButton: TANDMR_CButton);
+    procedure ClearButtons;
+    procedure SelectButton(AButton: TANDMR_CButton);
+    // Add public methods as needed
+
+  published
+    property Orientation: TANDMR_ButtonGroupOrientation read FOrientation write SetOrientation default bgoHorizontal;
+    property ButtonSpacing: Integer read FButtonSpacing write SetButtonSpacing default 5;
+    property SelectedButton: TANDMR_CButton read FSelectedButton write SelectButton;
+
+    property BorderSettings: TBorderSettings read FBorderSettings write SetBorderSettings;
+    property HoverSettings: THoverSettings read FHoverSettings write SetHoverSettings; // Group hover, not button hover
+    property SeparatorSettings: TSeparatorSettings read FSeparatorSettings write SetSeparatorSettings;
+    property AllowMultiSelect: Boolean read FAllowMultiSelect write SetAllowMultiSelect default False; // Added
+
+    property ActiveButtonColor: TColor read FActiveButtonColor write SetActiveButtonColor default clHighlight;
+    property InactiveButtonColor: TColor read FInactiveButtonColor write SetInactiveButtonColor default clBtnFace;
+    property ActiveButtonFontColor: TColor read FActiveButtonFontColor write SetActiveButtonFontColor default clWhite;
+    property InactiveButtonFontColor: TColor read FInactiveButtonFontColor write SetInactiveButtonFontColor default clBlack;
+
+    property Align;
+    property Enabled;
+    property Visible;
+    property OnClick;
+    property OnDblClick;
+    property Font;
+    property ParentShowHint;
+    property PopupMenu;
+    property ShowHint;
+    property TabOrder;
+    property TabStop default True;
+    property Transparent: Boolean read FTransparent write SetTransparent default False;
+  end;
+
+procedure Register;
+
+implementation
+
+procedure Register;
+begin
+  RegisterComponents('ANDMR', [TANDMR_CButtonGroup]);
+end;
+
+{ TANDMR_CButtonGroup }
+
+constructor TANDMR_CButtonGroup.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  ControlStyle := ControlStyle + [csOpaque, csAcceptsControls, csCaptureMouse, csClickEvents, csSetCaption, csDoubleClicks, csReplicatable];
+  Width := 200;
+  Height := 50;
+  TabStop := True;
+
+  FButtons := TObjectList.Create(True);
+  FTransparent := False; // Default value
+  ControlStyle := ControlStyle - [csParentBackground];
+  FOrientation := bgoHorizontal;
+  FButtonSpacing := 5;
+  FSelectedButton := nil;
+  FAllowMultiSelect := False; // Initialize new field
+
+  FActiveButtonColor := clHighlight;
+  FInactiveButtonColor := clBtnFace;
+  FActiveButtonFontColor := clWhite;
+  FInactiveButtonFontColor := clBlack;
+
+
+  FBorderSettings := TBorderSettings.Create;
+  FBorderSettings.OnChange := SettingsChanged;
+  FBorderSettings.CornerRadius := 8;
+  FBorderSettings.BackgroundColor := clNone; // Group background should be transparent or none
+  FBorderSettings.Color := clGray;
+  FBorderSettings.Thickness := 1;
+
+  // Group's own hover settings, not for individual buttons directly unless explicitly propagated
+  FHoverSettings := THoverSettings.Create(Self);
+  FHoverSettings.OnChange := SettingsChanged;
+  FHoverSettings.Enabled := False; // Typically, hover is on buttons, not the group itself
+
+  FSeparatorSettings := TSeparatorSettings.Create;
+  FSeparatorSettings.OnChange := SettingsChanged;
+  FSeparatorSettings.Visible := True;
+  FSeparatorSettings.Color := clMedGray;
+  FSeparatorSettings.Thickness := 1;
+  FSeparatorSettings.Padding := 0; // Separators are between buttons
+
+  Font.Name := 'Segoe UI';
+  Font.Size := 9;
+end;
+
+destructor TANDMR_CButtonGroup.Destroy;
+begin
+  FButtons.Free;
+  FBorderSettings.Free;
+  FHoverSettings.Free;
+  FSeparatorSettings.Free;
+  inherited Destroy;
+end;
+
+procedure TANDMR_CButtonGroup.Paint;
+var
+  i: Integer;
+  ButtonRect: TRect;
+  CurrentPos: Integer;
+  Btn: TANDMR_CButton;
+  SepRect: TRect;
+  Path: TGPGraphicsPath;
+  LRectF: TGPRectF;
+  LRadiusValue : Single;
+  LG: TGPGraphics;
+begin
+  inherited Paint;
+
+  LG := TGPGraphics.Create(Canvas.Handle);
+  try
+    LG.SetSmoothingMode(SmoothingModeAntiAlias);
+    LRectF.X := 0.0;
+    LRectF.Y := 0.0;
+    LRectF.Width := Self.Width; // Self.Width is Integer, implicitly converted to Single
+    LRectF.Height := Self.Height; // Self.Height is Integer, implicitly converted to Single
+    if FBorderSettings.Thickness > 0 then
+    begin
+        LRectF.X := FBorderSettings.Thickness / 2;
+        LRectF.Y := FBorderSettings.Thickness / 2;
+        LRectF.Width := Width - FBorderSettings.Thickness;
+        LRectF.Height := Height - FBorderSettings.Thickness;
+    end;
+    LRadiusValue := Min(FBorderSettings.CornerRadius, Min(LRectF.Width, LRectF.Height) / 2.0);
+    LRadiusValue := Max(0, LRadiusValue);
+
+    Path := TGPGraphicsPath.Create;
+    try
+      CreateGPRoundedPath(Path, LRectF, LRadiusValue, FBorderSettings.RoundCornerType);
+      // Fill background of the group if specified
+      if FBorderSettings.BackgroundColor <> clNone then
+      begin
+        var FillBrush: TGPSolidBrush;
+        FillBrush := TGPSolidBrush.Create(ColorToARGB(FBorderSettings.BackgroundColor, IfThen(Self.Transparent, 0, 255))));
+        try
+          LG.FillPath(FillBrush, Path);
+        finally
+          FillBrush.Free;
+        end;
+      end;
+      // Draw group border
+      if FBorderSettings.Visible and (FBorderSettings.Thickness > 0) then
+      begin
+        var Pen: TGPPen;
+        Pen := TGPPen.Create(ColorToARGB(FBorderSettings.Color), FBorderSettings.Thickness);
+        try
+          LG.DrawPath(Pen, Path);
+        finally
+          Pen.Free;
+        end;
+      end;
+    finally
+      Path.Free;
+    end;
+
+    // Draw Separators
+    if FSeparatorSettings.Visible and (FSeparatorSettings.Thickness > 0) and (FButtons.Count > 1) then
+    begin
+      var // Local variables for separator drawing
+        SepPenObj: TGPPen;
+        BtnBefore: TANDMR_CButton;
+        i: Integer;
+        SepX, ActualSepTop, ActualSepBottom: Single; // For Horizontal orientation
+        SepY, ActualSepLeft, ActualSepRight: Single; // For Vertical orientation
+
+      SepPenObj := TGPPen.Create(ColorToARGB(FSeparatorSettings.Color, 255), FSeparatorSettings.Thickness);
+      try
+        for i := 0 to FButtons.Count - 2 do // Iterate up to the second-to-last button
+        begin
+          BtnBefore := TANDMR_CButton(FButtons[i]);
+
+          if FOrientation = bgoHorizontal then
+          begin
+            SepX := BtnBefore.Left + BtnBefore.Width + (FButtonSpacing / 2.0);
+            ActualSepTop := BtnBefore.Top + FSeparatorSettings.Padding;
+            ActualSepBottom := BtnBefore.Top + BtnBefore.Height - FSeparatorSettings.Padding;
+
+            if ActualSepBottom > ActualSepTop then
+            begin
+              LG.DrawLine(SepPenObj, SepX, ActualSepTop, SepX, ActualSepBottom);
+            end;
+          end
+          else // bgoVertical
+          begin
+            SepY := BtnBefore.Top + BtnBefore.Height + (FButtonSpacing / 2.0);
+            ActualSepLeft := BtnBefore.Left + FSeparatorSettings.Padding;
+            ActualSepRight := BtnBefore.Left + BtnBefore.Width - FSeparatorSettings.Padding;
+
+            if ActualSepRight > ActualSepLeft then
+            begin
+              LG.DrawLine(SepPenObj, ActualSepLeft, SepY, ActualSepRight, SepY);
+            end;
+          end;
+        end;
+      finally
+        SepPenObj.Free;
+      end;
+    end;
+
+  finally
+    LG.Free;
+  end;
+
+
+  // Button layout and separator drawing logic will be called from Resize or when buttons change
+  // For now, this Paint focuses on the group's own border/background
+end;
+
+procedure TANDMR_CButtonGroup.Loaded;
+begin
+  inherited Loaded;
+  UpdateButtonsStyle;
+  Resize; // Initial layout
+end;
+
+procedure TANDMR_CButtonGroup.Notification(AComponent: TComponent; Operation: TOperation);
+begin
+  inherited Notification(AComponent, Operation);
+  if (Operation = opRemove) and (AComponent is TANDMR_CButton) then
+  begin
+    if FButtons.IndexOf(AComponent as TANDMR_CButton) <> -1 then
+      RemoveButton(AComponent as TANDMR_CButton); // This will also update layout via Resize
+  end;
+end;
+
+procedure TANDMR_CButtonGroup.Resize;
+var
+  i: Integer;
+  CurrentPos, TotalButtonSize, TotalSpacing, ButtonSize, StartPos: Integer;
+  Btn: TANDMR_CButton;
+begin
+  inherited Resize;
+
+  if FButtons.Count = 0 then Exit;
+
+  TotalSpacing := FButtonSpacing * (FButtons.Count - 1);
+  if TotalSpacing < 0 then TotalSpacing := 0;
+
+  if FOrientation = bgoHorizontal then
+  begin
+    TotalButtonSize := Width - TotalSpacing - FBorderSettings.Thickness * 2 - FSeparatorSettings.Padding * 2;
+    if TotalButtonSize < 0 then TotalButtonSize := 0;
+    ButtonSize := IfThen(FButtons.Count > 0, TotalButtonSize div FButtons.Count, 0);
+    StartPos := FBorderSettings.Thickness + FSeparatorSettings.Padding;
+    CurrentPos := StartPos;
+
+    for i := 0 to FButtons.Count - 1 do
+    begin
+      Btn := TANDMR_CButton(FButtons[i]);
+      Btn.SetBounds(CurrentPos, FBorderSettings.Thickness + FSeparatorSettings.Padding, ButtonSize, Height - (FBorderSettings.Thickness * 2) - (FSeparatorSettings.Padding * 2));
+      CurrentPos := CurrentPos + ButtonSize + FButtonSpacing;
+    end;
+  end
+  else // bgoVertical
+  begin
+    TotalButtonSize := Height - TotalSpacing - FBorderSettings.Thickness * 2 - FSeparatorSettings.Padding * 2;
+    if TotalButtonSize < 0 then TotalButtonSize := 0;
+    ButtonSize := IfThen(FButtons.Count > 0, TotalButtonSize div FButtons.Count, 0);
+    StartPos := FBorderSettings.Thickness + FSeparatorSettings.Padding;
+    CurrentPos := StartPos;
+
+    for i := 0 to FButtons.Count - 1 do
+    begin
+      Btn := TANDMR_CButton(FButtons[i]);
+      Btn.SetBounds(FBorderSettings.Thickness + FSeparatorSettings.Padding, CurrentPos, Width - (FBorderSettings.Thickness * 2) - (FSeparatorSettings.Padding * 2), ButtonSize);
+      CurrentPos := CurrentPos + ButtonSize + FButtonSpacing;
+    end;
+  end;
+  UpdateButtonsStyle; // Ensure styles are reapplied after resize/reposition
+  Invalidate;
+end;
+
+
+procedure TANDMR_CButtonGroup.SetOrientation(const Value: TANDMR_ButtonGroupOrientation);
+begin
+  if FOrientation <> Value then
+  begin
+    FOrientation := Value;
+    Resize; // Re-layout buttons
+  end;
+end;
+
+procedure TANDMR_CButtonGroup.SetButtonSpacing(const Value: Integer);
+begin
+  if FButtonSpacing <> Max(0, Value) then
+  begin
+    FButtonSpacing := Max(0, Value);
+    Resize; // Re-layout buttons
+  end;
+end;
+
+procedure TANDMR_CButtonGroup.SetBorderSettings(const Value: TBorderSettings);
+begin
+  FBorderSettings.Assign(Value);
+  Resize; // Border thickness might change layout
+  Repaint;
+end;
+
+procedure TANDMR_CButtonGroup.SetHoverSettings(const Value: THoverSettings);
+begin
+  FHoverSettings.Assign(Value); // Group hover, not directly applied to buttons here
+  Repaint;
+end;
+
+procedure TANDMR_CButtonGroup.SetSeparatorSettings(const Value: TSeparatorSettings);
+begin
+  FSeparatorSettings.Assign(Value);
+  Resize; // Separator padding might change layout
+  Repaint;
+end;
+
+procedure TANDMR_CButtonGroup.SetAllowMultiSelect(const Value: Boolean);
+begin
+  if FAllowMultiSelect <> Value then
+  begin
+    FAllowMultiSelect := Value;
+    if not FAllowMultiSelect and Assigned(FSelectedButton) then
+    begin
+      // If switching to single select, ensure only FSelectedButton is "active"
+      // No specific action needed here if SelectButton already handles single selection logic
+    end;
+    UpdateButtonsStyle; // Re-apply styles based on new selection mode
+    Repaint;
+  end;
+end;
+
+procedure TANDMR_CButtonGroup.SetActiveButtonColor(const Value: TColor);
+begin
+  if FActiveButtonColor <> Value then
+  begin
+    FActiveButtonColor := Value;
+    UpdateButtonsStyle;
+    Repaint;
+  end;
+end;
+
+procedure TANDMR_CButtonGroup.SetInactiveButtonColor(const Value: TColor);
+begin
+  if FInactiveButtonColor <> Value then
+  begin
+    FInactiveButtonColor := Value;
+    UpdateButtonsStyle;
+    Repaint;
+  end;
+end;
+
+procedure TANDMR_CButtonGroup.SetActiveButtonFontColor(const Value: TColor);
+begin
+  if FActiveButtonFontColor <> Value then
+  begin
+    FActiveButtonFontColor := Value;
+    UpdateButtonsStyle;
+    Repaint;
+  end;
+end;
+
+procedure TANDMR_CButtonGroup.SetInactiveButtonFontColor(const Value: TColor);
+begin
+  if FInactiveButtonFontColor <> Value then
+  begin
+    FInactiveButtonFontColor := Value;
+    UpdateButtonsStyle;
+    Repaint;
+  end;
+end;
+
+procedure TANDMR_CButtonGroup.SettingsChanged(Sender: TObject);
+begin
+  Resize; // Some settings might affect layout
+  Repaint;
+end;
+
+procedure TANDMR_CButtonGroup.ButtonClickHandler(Sender: TObject);
+var
+  ClickedButton: TANDMR_CButton;
+begin
+  if Sender is TANDMR_CButton then
+  begin
+    ClickedButton := TANDMR_CButton(Sender);
+    if FAllowMultiSelect then
+    begin
+      // Toggle selection for multi-select mode (not fully implemented yet)
+      // For now, just call SelectButton which will behave as single select
+      SelectButton(ClickedButton);
+    end
+    else
+    begin
+      SelectButton(ClickedButton);
+    end;
+
+    if Assigned(OnClick) then
+      OnClick(Self);
+  end;
+end;
+
+function TANDMR_CButtonGroup.AddButton(ACaption: string = ''; AImage: TPicture = nil): TANDMR_CButton;
+var
+  NewButton: TANDMR_CButton;
+begin
+  NewButton := TANDMR_CButton.Create(Self);
+  NewButton.Parent := Self;
+  NewButton.Caption := ACaption;
+  if AImage <> nil then
+    NewButton.ImageSettings.Picture.Assign(AImage);
+
+  NewButton.ControlStyle := NewButton.ControlStyle - [csSetCaption]; // Group manages caption implications
+  NewButton.OnClick := ButtonClickHandler;
+  NewButton.Visible := True;
+  NewButton.TabStop := False; // Group is the TabStop
+
+  // Initial styling - will be overridden by UpdateButtonsStyle
+  NewButton.BorderSettings.CornerRadius := Max(0, FBorderSettings.CornerRadius - 1); // Group radius is outer
+  NewButton.BorderSettings.Color := FBorderSettings.Color; // Default border
+  NewButton.BorderSettings.Thickness := 1; // Standard button border
+  NewButton.BorderSettings.BackgroundColor := FInactiveButtonColor;
+  NewButton.CaptionSettings.Font.Color := FInactiveButtonFontColor;
+
+  // Assign group's hover settings to the button for consistent hover effect
+  NewButton.HoverSettings.Assign(Self.FHoverSettings);
+  // More specific button hover styling if needed:
+  NewButton.HoverSettings.BackgroundColor := LighterColor(FInactiveButtonColor, 15);
+  NewButton.HoverSettings.BorderColor := FActiveButtonColor;
+  NewButton.HoverSettings.FontColor := FActiveButtonFontColor;
+  NewButton.HoverSettings.Enabled := True; // Enable hover for buttons
+
+  FButtons.Add(NewButton);
+  UpdateButtonsStyle; // Apply consistent styling
+  Resize; // Re-layout
+  Result := NewButton;
+end;
+
+procedure TANDMR_CButtonGroup.RemoveButton(AButton: TANDMR_CButton);
+var
+  idx: Integer;
+begin
+  idx := FButtons.IndexOf(AButton);
+  if idx <> -1 then
+  begin
+    if FSelectedButton = AButton then
+      FSelectedButton := nil;
+    FButtons.Remove(AButton); // TObjectList frees if it owns
+    // AButton.Free; // No, TObjectList(True) handles freeing
+    if FButtons.Count = 0 then FSelectedButton := nil;
+    Resize; // Re-layout
+  end;
+end;
+
+procedure TANDMR_CButtonGroup.ClearButtons;
+begin
+  FSelectedButton := nil; // Clear selection first
+  // TObjectList owns the buttons, so clearing it will free them.
+  FButtons.Clear;
+  Resize; // Re-layout
+end;
+
+procedure TANDMR_CButtonGroup.SelectButton(AButton: TANDMR_CButton);
+begin
+  if not Enabled then Exit;
+  if FAllowMultiSelect then
+  begin
+    // Multi-select logic (not the primary requirement for now)
+    // For now, even in multi-select mode, we'll just mark AButton as the "last selected" or "primary selected".
+    // A full multi-select would involve a list of selected buttons and checking if AButton is in it.
+    // If AButton is in FButtons list:
+    if FButtons.IndexOf(AButton) <> -1 then
+    begin
+        if FSelectedButton <> AButton then // If it's a new button to "select"
+        begin
+            FSelectedButton := AButton; // Update the primary selected button
+        end
+        else // If clicking the already primary selected button in multi-select (optional: deselect)
+        begin
+             // FSelectedButton := nil; // Optional: allow deselecting the primary in multi-mode
+        end;
+    end else
+    begin
+        FSelectedButton := nil; // Button not in group
+    end;
+  end
+  else // Single selection mode
+  begin
+    if FSelectedButton = AButton then
+    begin
+        // Optional: Allow deselecting by clicking the selected button again
+        // FSelectedButton := nil;
+    end
+    else
+    begin
+      FSelectedButton := nil; // Clear previous before searching
+      if FButtons.IndexOf(AButton) <> -1 then
+      begin
+        FSelectedButton := AButton;
+      end;
+    end;
+  end;
+
+  UpdateButtonsStyle;
+  Repaint; // Repaint the group and its buttons
+end;
+
+procedure TANDMR_CButtonGroup.UpdateButtonsStyle;
+var
+  i: Integer;
+  Btn: TANDMR_CButton;
+  IsSelected: Boolean;
+  IsFirst, IsLast, IsMiddle: Boolean;
+  EffectiveRadius: Integer;
+begin
+  EffectiveRadius := Max(0, FBorderSettings.CornerRadius -1); // Inner buttons have slightly less or specific radius handling
+
+  for i := 0 to FButtons.Count - 1 do
+  begin
+    Btn := TANDMR_CButton(FButtons[i]);
+    IsSelected := (Btn = FSelectedButton); // Simplified for single selection focus
+
+    if IsSelected then
+    begin
+      Btn.BorderSettings.BackgroundColor := FActiveButtonColor;
+      Btn.CaptionSettings.Font.Color := FActiveButtonFontColor;
+      // Potentially different border for selected
+      Btn.BorderSettings.Color := DarkerColor(FActiveButtonColor, 20);
+    end
+    else
+    begin
+      Btn.BorderSettings.BackgroundColor := FInactiveButtonColor;
+      Btn.CaptionSettings.Font.Color := FInactiveButtonFontColor;
+      Btn.BorderSettings.Color := FBorderSettings.Color; // Default border color
+    end;
+
+    // Adjust corner radius based on position for a continuous look
+    IsFirst := (i = 0);
+    IsLast := (i = FButtons.Count - 1);
+    IsMiddle := not IsFirst and not IsLast;
+
+    Btn.BorderSettings.RoundCornerType := rctNone; // Default for middle buttons
+
+    if FButtons.Count = 1 then // Single button takes full group radius
+    begin
+        Btn.BorderSettings.RoundCornerType := FBorderSettings.RoundCornerType;
+        Btn.BorderSettings.CornerRadius := FBorderSettings.CornerRadius;
+    end
+    else if FOrientation = bgoHorizontal then
+    begin
+      if IsFirst then
+      begin
+        Btn.BorderSettings.CornerRadius := EffectiveRadius;
+        Btn.BorderSettings.RoundCornerType := rctLeft;
+        if FBorderSettings.RoundCornerType = rctAll then Btn.BorderSettings.RoundCornerType := rctLeft
+        else if FBorderSettings.RoundCornerType = rctTopLeft then Btn.BorderSettings.RoundCornerType := rctTopLeft
+        else if FBorderSettings.RoundCornerType = rctBottomLeft then Btn.BorderSettings.RoundCornerType := rctBottomLeft
+        else if FBorderSettings.RoundCornerType = rctTop then Btn.BorderSettings.RoundCornerType := rctTopLeft
+        else if FBorderSettings.RoundCornerType = rctBottom then Btn.BorderSettings.RoundCornerType := rctBottomLeft;
+
+      end
+      else if IsLast then
+      begin
+        Btn.BorderSettings.CornerRadius := EffectiveRadius;
+        Btn.BorderSettings.RoundCornerType := rctRight;
+        if FBorderSettings.RoundCornerType = rctAll then Btn.BorderSettings.RoundCornerType := rctRight
+        else if FBorderSettings.RoundCornerType = rctTopRight then Btn.BorderSettings.RoundCornerType := rctTopRight
+        else if FBorderSettings.RoundCornerType = rctBottomRight then Btn.BorderSettings.RoundCornerType := rctBottomRight
+        else if FBorderSettings.RoundCornerType = rctTop then Btn.BorderSettings.RoundCornerType := rctTopRight
+        else if FBorderSettings.RoundCornerType = rctBottom then Btn.BorderSettings.RoundCornerType := rctBottomRight;
+      end
+      else // Middle buttons
+      begin
+        Btn.BorderSettings.CornerRadius := 0; // No radius for middle buttons in horizontal
+      end;
+    end
+    else // bgoVertical
+    begin
+      if IsFirst then
+      begin
+        Btn.BorderSettings.CornerRadius := EffectiveRadius;
+        Btn.BorderSettings.RoundCornerType := rctTop;
+         if FBorderSettings.RoundCornerType = rctAll then Btn.BorderSettings.RoundCornerType := rctTop
+        else if FBorderSettings.RoundCornerType = rctTopLeft then Btn.BorderSettings.RoundCornerType := rctTopLeft
+        else if FBorderSettings.RoundCornerType = rctTopRight then Btn.BorderSettings.RoundCornerType := rctTopRight
+        else if FBorderSettings.RoundCornerType = rctLeft then Btn.BorderSettings.RoundCornerType := rctTopLeft
+        else if FBorderSettings.RoundCornerType = rctRight then Btn.BorderSettings.RoundCornerType := rctTopRight;
+      end
+      else if IsLast then
+      begin
+        Btn.BorderSettings.CornerRadius := EffectiveRadius;
+        Btn.BorderSettings.RoundCornerType := rctBottom;
+        if FBorderSettings.RoundCornerType = rctAll then Btn.BorderSettings.RoundCornerType := rctBottom
+        else if FBorderSettings.RoundCornerType = rctBottomLeft then Btn.BorderSettings.RoundCornerType := rctBottomLeft
+        else if FBorderSettings.RoundCornerType = rctBottomRight then Btn.BorderSettings.RoundCornerType := rctBottomRight
+        else if FBorderSettings.RoundCornerType = rctLeft then Btn.BorderSettings.RoundCornerType := rctBottomLeft
+        else if FBorderSettings.RoundCornerType = rctRight then Btn.BorderSettings.RoundCornerType := rctBottomRight;
+      end
+      else // Middle buttons
+      begin
+        Btn.BorderSettings.CornerRadius := 0; // No radius for middle buttons in vertical
+      end;
+    end;
+    Btn.Repaint;
+  end;
+  Repaint; // Group itself might need repaint due to selection changes affecting borders/separators
+end;
+
+end.


### PR DESCRIPTION
Added a 'Transparent' property to the TANDMR_CButtonGroup component.
- If True, the group's background (if FBorderSettings.BackgroundColor is set) will be rendered with full transparency (alpha 0), and ControlStyle is updated to include csParentBackground and remove csOpaque.
- If False (default), the group's background is rendered opaquely, and ControlStyle includes csOpaque.

This resolves an E2003 Undeclared identifier error for 'Transparent' that occurred in the Paint method when trying to use this property before it was implemented for the group. The Paint method now correctly uses this property to control the alpha channel of its background fill.